### PR TITLE
feat: add workflow_dispatch trigger to canary-release workflow

### DIFF
--- a/.github/workflows/canary-release.yml
+++ b/.github/workflows/canary-release.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
 
 permissions:
   contents: read


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/canary-release.yml` file. The change adds the `workflow_dispatch` event to the `on:` section, allowing the workflow to be manually triggered.