### PR TITLE
fix: disable portmapper services in setup script

### DIFF
--- a/setup/setup-canary.sh
+++ b/setup/setup-canary.sh
@@ -80,10 +80,17 @@ wait_until_all_pods_running() {
 # Prompt for network interface
 select_network_interface
 
+# !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+# THIS MUST BE INSTALLED ON ALL NODES --> https://longhorn.io/docs/1.7.2/deploy/install/#installing-nfsv4-client
+# !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 # install nfs-common and open-iscsi
 echo "Installing nfs-common..."
 sudo apt-get update
 sudo apt-get install open-iscsi nfs-common -y
+
+# Disable portmapper services --> https://github.com/biersoeckli/QuickStack/issues/18
+systemctl stop rpcbind.service rpcbind.socket
+systemctl disable rpcbind.service rpcbind.socket
 
 # Installation of k3s
 #curl -sfL https://get.k3s.io | INSTALL_K3S_EXEC="--node-ip=192.168.1.2 --advertise-address=192.168.1.2 --node-external-ip=188.245.236.232 --flannel-iface=enp7s0" INSTALL_K3S_VERSION="v1.31.3+k3s1" sh -
@@ -100,13 +107,6 @@ wait_until_all_pods_running
 sudo kubectl apply -f https://raw.githubusercontent.com/longhorn/longhorn/v1.7.2/deploy/longhorn.yaml
 echo "Waiting for Longhorn to start..."
 wait_until_all_pods_running
-
-# !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-# THIS MUST BE INSTALLED ON ALL NODES --> https://longhorn.io/docs/1.7.2/deploy/install/#installing-nfsv4-client
-# !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-
-#sudo kubectl apply -f https://raw.githubusercontent.com/longhorn/longhorn/v1.6.0/deploy/prerequisite/longhorn-nfs-installation.yaml
-#wait_until_all_pods_running
 
 # Installation of Cert-Manager
 sudo kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.16.1/cert-manager.yaml

--- a/setup/setup-worker.sh
+++ b/setup/setup-worker.sh
@@ -57,9 +57,16 @@ select_network_interface() {
 # Call the function to select the network interface
 select_network_interface
 
+# !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+# THIS MUST BE INSTALLED ON ALL NODES --> https://longhorn.io/docs/1.7.2/deploy/install/#installing-nfsv4-client
+# !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 # install nfs-common and open-iscsi
 sudo apt-get update
 sudo apt-get install open-iscsi nfs-common -y
+
+# Disable portmapper services --> https://github.com/biersoeckli/QuickStack/issues/18
+systemctl stop rpcbind.service rpcbind.socket
+systemctl disable rpcbind.service rpcbind.socket
 
 # Installation of k3s
 echo "Installing k3s with --flannel-iface=$selected_iface"

--- a/setup/setup.sh
+++ b/setup/setup.sh
@@ -80,10 +80,16 @@ wait_until_all_pods_running() {
 # Prompt for network interface
 select_network_interface
 
-# install nfs-common and open-iscsi
+# !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+# THIS MUST BE INSTALLED ON ALL NODES --> https://longhorn.io/docs/1.7.2/deploy/install/#installing-nfsv4-client
+# !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 echo "Installing nfs-common..."
 sudo apt-get update
 sudo apt-get install open-iscsi nfs-common -y
+
+# Disable portmapper services --> https://github.com/biersoeckli/QuickStack/issues/18
+systemctl stop rpcbind.service rpcbind.socket
+systemctl disable rpcbind.service rpcbind.socket
 
 # Installation of k3s
 #curl -sfL https://get.k3s.io | INSTALL_K3S_EXEC="--node-ip=192.168.1.2 --advertise-address=192.168.1.2 --node-external-ip=188.245.236.232 --flannel-iface=enp7s0" INSTALL_K3S_VERSION="v1.31.3+k3s1" sh -
@@ -100,13 +106,6 @@ wait_until_all_pods_running
 sudo kubectl apply -f https://raw.githubusercontent.com/longhorn/longhorn/v1.7.2/deploy/longhorn.yaml
 echo "Waiting for Longhorn to start..."
 wait_until_all_pods_running
-
-# !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-# THIS MUST BE INSTALLED ON ALL NODES --> https://longhorn.io/docs/1.7.2/deploy/install/#installing-nfsv4-client
-# !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-
-#sudo kubectl apply -f https://raw.githubusercontent.com/longhorn/longhorn/v1.6.0/deploy/prerequisite/longhorn-nfs-installation.yaml
-#wait_until_all_pods_running
 
 # Installation of Cert-Manager
 sudo kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.16.1/cert-manager.yaml


### PR DESCRIPTION
Disabled portmapper services to address QuickStack issue #18 in `setup/setup-canary.sh`, `setup/setup-worker.sh`, and `setup/setup.sh`. [[1]](diffhunk://#diff-f56f2c020afba2e85f2d9378e441707484a7867fabbf0d96cc3bac8304531fcaR83-R94) [[2]](diffhunk://#diff-686e0da551c1bd81decd30c2e5eda91cc1e5ca8a4b94e9fe19240615b37b6a60R60-R70) [[3]](diffhunk://#diff-274e1ea694cc750be535f6e98389cc96c3dbbd7a4a023e0b030f53a620b38c64L83-R93)
