### PR TITLE
Fix/multipathd in setup script and registry deployment

### DIFF
--- a/setup/setup-canary.sh
+++ b/setup/setup-canary.sh
@@ -102,6 +102,18 @@ echo "Using Longhorn version: $LONGHORN_VERSION"
 sudo systemctl stop rpcbind.service rpcbind.socket
 sudo systemctl disable rpcbind.service rpcbind.socket
 
+if systemctl list-units --full --all | grep -q 'multipathd'; then
+  sudo systemctl stop multipathd
+  sudo systemctl disable multipathd
+fi
+
+if ! lsmod | grep -q dm_crypt; then
+  sudo modprobe dm_crypt
+fi
+if ! grep -q 'dm_crypt' /etc/modules; then
+  echo "dm_crypt" | sudo tee -a /etc/modules
+fi
+
 # Installation of k3s
 #curl -sfL https://get.k3s.io | INSTALL_K3S_EXEC="--node-ip=192.168.1.2 --advertise-address=192.168.1.2 --node-external-ip=188.245.236.232 --flannel-iface=enp7s0" INSTALL_K3S_VERSION="v1.31.3+k3s1" sh -
 

--- a/setup/setup-worker.sh
+++ b/setup/setup-worker.sh
@@ -76,6 +76,18 @@ echo "Using K3s version: $K3S_VERSION"
 sudo systemctl stop rpcbind.service rpcbind.socket
 sudo systemctl disable rpcbind.service rpcbind.socket
 
+if systemctl list-units --full --all | grep -q 'multipathd'; then
+  sudo systemctl stop multipathd
+  sudo systemctl disable multipathd
+fi
+
+if ! lsmod | grep -q dm_crypt; then
+  sudo modprobe dm_crypt
+fi
+if ! grep -q 'dm_crypt' /etc/modules; then
+  echo "dm_crypt" | sudo tee -a /etc/modules
+fi
+
 # Installation of k3s
 echo "Installing k3s with --flannel-iface=$selected_iface"
 curl -sfL https://get.k3s.io | INSTALL_K3S_EXEC="--flannel-iface=$selected_iface" INSTALL_K3S_VERSION="$K3S_VERSION" K3S_URL=${K3S_URL} K3S_TOKEN=${JOIN_TOKEN} sh -

--- a/setup/setup.sh
+++ b/setup/setup.sh
@@ -101,6 +101,20 @@ echo "Using Longhorn version: $LONGHORN_VERSION"
 sudo systemctl stop rpcbind.service rpcbind.socket
 sudo systemctl disable rpcbind.service rpcbind.socket
 
+# Disable multipathd service, as it can cause issues with Longhorn --> https://longhorn.io/kb/troubleshooting-volume-with-multipath
+if systemctl list-units --full --all | grep -q 'multipathd'; then
+  sudo systemctl stop multipathd
+  sudo systemctl disable multipathd
+fi
+
+# Enable dm_crypt module for Longhorn encryption support
+if ! lsmod | grep -q dm_crypt; then
+  sudo modprobe dm_crypt
+fi
+if ! grep -q 'dm_crypt' /etc/modules; then
+  echo "dm_crypt" | sudo tee -a /etc/modules
+fi
+
 # Installation of k3s
 #curl -sfL https://get.k3s.io | INSTALL_K3S_EXEC="--node-ip=192.168.1.2 --advertise-address=192.168.1.2 --node-external-ip=188.245.236.232 --flannel-iface=enp7s0" INSTALL_K3S_VERSION="v1.31.3+k3s1" sh -
 


### PR DESCRIPTION
This pull request introduces important improvements to the setup scripts and registry deployment logic, primarily focused on ensuring compatibility and reliability with Longhorn and the internal registry. The main changes include disabling the `multipathd` service and enabling the `dm_crypt` kernel module for Longhorn support, as well as updating the registry deployment process to always refresh storage configuration settings and use a specific registry image version.