### PR TITLE
fix: extend validation for git URL in app source info model

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -23,10 +23,12 @@ A clear and concise description of what you expected to happen.
 **Screenshots**
 If applicable, add screenshots to help explain your problem.
 
-**Desktop (please complete the following information):**
- - OS: [e.g. iOS]
- - Browser [e.g. chrome, safari]
- - Version [e.g. 22]
+**Your Environment**
+ - Browser [e.g. chrome, safari]: 
+ - QuickStack Version [e.g. 0.0.8]:
+ - Server OS [e.g. Ubuntu 20.04]:
+ - Server architecture [e.g. x86_64, arm64]:
+ - Server Storage Capacity [e.g. 40 GB]:
 
 **Additional context**
 Add any other context about the problem here.

--- a/src/shared/model/app-source-info.model.ts
+++ b/src/shared/model/app-source-info.model.ts
@@ -3,8 +3,17 @@ import { z } from "zod";
 export const appSourceTypeZodModel = z.enum(["GIT", "CONTAINER"]);
 export const appTypeZodModel = z.enum(["APP", "POSTGRES", "MYSQL", "MARIADB", "MONGODB", "REDIS"]);
 
+const gitHttpsUrlRegex = /^https:\/\/[^\s/]+(?::\d+)?(\/[^\s]*)+$/;
+const gitHubGitLabDotGitRegex = /^https:\/\/(github\.com|gitlab\.com)\//;
+const gitUrlValidationMessage = 'Must be a valid HTTPS git URL. For GitHub/GitLab the .git suffix is required (e.g. https://github.com/user/repo.git)';
+const gitUrlValidation = (val: string) => {
+  if (!gitHttpsUrlRegex.test(val)) return false;
+  if (gitHubGitLabDotGitRegex.test(val) && !val.endsWith('.git')) return false;
+  return true;
+};
+
 export const appSourceInfoGitZodModel = z.object({
-  gitUrl: z.string().trim(),
+  gitUrl: z.string().trim().refine(gitUrlValidation, gitUrlValidationMessage),
   gitBranch: z.string().trim(),
   gitUsername: z.string().trim().nullish(),
   gitToken: z.string().trim().nullish(),
@@ -25,7 +34,7 @@ export const appSourceInfoInputZodModel = z.object({
   containerRegistryUsername: z.string().nullish(),
   containerRegistryPassword: z.string().nullish(),
 
-  gitUrl: z.string().trim().nullish(),
+  gitUrl: z.string().trim().refine((val) => !val || gitUrlValidation(val), gitUrlValidationMessage).nullish(),
   gitBranch: z.string().trim().nullish(),
   gitUsername: z.string().trim().nullish(),
   gitToken: z.string().trim().nullish(),


### PR DESCRIPTION
This pull request introduces improved validation for Git URLs in the app source models. Without a .git suffix in the HTTPS Git URL, buildkit is not able to clone the repository for building the Docker image.