### PR TITLE
feat: add privileged container mode for apps

### DIFF
--- a/prisma/migrations/20260314233637_add_privileged_container_mode/migration.sql
+++ b/prisma/migrations/20260314233637_add_privileged_container_mode/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "App" ADD COLUMN "securityContextPrivileged" BOOLEAN DEFAULT false;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -188,6 +188,7 @@ model App {
   securityContextRunAsUser  Int?
   securityContextRunAsGroup Int?
   securityContextFsGroup    Int?
+  securityContextPrivileged Boolean? @default(false)
 
   gitUrl         String?
   gitBranch      String?

--- a/src/app/project/app/[appId]/general/actions.ts
+++ b/src/app/project/app/[appId]/general/actions.ts
@@ -75,6 +75,7 @@ export const saveGeneralAppContainerConfig = async (prevState: any, inputData: A
             securityContextRunAsUser: validatedData.securityContextRunAsUser ?? null,
             securityContextRunAsGroup: validatedData.securityContextRunAsGroup ?? null,
             securityContextFsGroup: validatedData.securityContextFsGroup ?? null,
+            securityContextPrivileged: validatedData.securityContextPrivileged ?? false,
             id: appId,
         });
     });

--- a/src/app/project/app/[appId]/general/app-container-config.tsx
+++ b/src/app/project/app/[appId]/general/app-container-config.tsx
@@ -3,8 +3,8 @@
 import { SubmitButton } from "@/components/custom/submit-button";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from "@/components/ui/card";
-import { Checkbox } from "@/components/ui/checkbox";
-import { Form, FormControl, FormDescription, FormField, FormItem, FormLabel, FormMessage } from "@/components/ui/form";
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from "@/components/ui/form";
 import { FormUtils } from "@/frontend/utils/form.utilts";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useForm, useFieldArray } from "react-hook-form";
@@ -12,15 +12,43 @@ import { saveGeneralAppContainerConfig } from "./actions";
 import { useFormState } from "react-dom";
 import { ServerActionResult } from "@/shared/model/server-action-error-return.model";
 import { Input } from "@/components/ui/input";
-import { useEffect } from "react";
+import { Separator } from "@/components/ui/separator";
+import { Switch } from "@/components/ui/switch";
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
+import { type ReactNode, useEffect } from "react";
 import { toast } from "sonner";
 import { AppExtendedModel } from "@/shared/model/app-extended.model";
-import { Trash2, Plus } from "lucide-react";
+import { HelpCircle, Plus, Trash2 } from "lucide-react";
 import { z } from "zod";
 import { appContainerConfigZodModel } from "@/shared/model/app-container-config.model";
-import FormLabelWithQuestion from "@/components/custom/form-label-with-question";
 
 export type AppContainerConfigInputModel = z.infer<typeof appContainerConfigZodModel>;
+
+function LabelWithHint({ children, hint }: { children: ReactNode; hint?: ReactNode }) {
+    return (
+        <div className="flex items-center gap-1.5">
+            <FormLabel className="m-0">{children}</FormLabel>
+            {hint && (
+                <Tooltip>
+                    <TooltipTrigger asChild>
+                        <Button
+                            type="button"
+                            variant="ghost"
+                            size="icon"
+                            className="h-5 w-5 text-muted-foreground hover:text-foreground"
+                        >
+                            <HelpCircle className="h-3.5 w-3.5" />
+                            <span className="sr-only">More information</span>
+                        </Button>
+                    </TooltipTrigger>
+                    <TooltipContent side="top" className="max-w-80">
+                        <div className="text-sm leading-relaxed">{hint}</div>
+                    </TooltipContent>
+                </Tooltip>
+            )}
+        </div>
+    );
+}
 
 export default function GeneralAppContainerConfig({ app, readonly }: {
     app: AppExtendedModel;
@@ -64,194 +92,238 @@ export default function GeneralAppContainerConfig({ app, readonly }: {
         FormUtils.mapValidationErrorsToForm<typeof appContainerConfigZodModel>(state, form)
     }, [state]);
 
+    const values = form.watch();
+
     return (
         <Card>
             <CardHeader>
                 <CardTitle>Container Configuration</CardTitle>
                 <CardDescription>
-                    Override the container&apos;s command and arguments. Leave empty to use the image defaults.
+                    Override image defaults only when your workload needs custom startup behavior or Linux security settings.
                 </CardDescription>
             </CardHeader>
             <Form {...form}>
-                <form action={(e) => form.handleSubmit((data) => {
-                    return formAction(data);
-                })()}>
-                    <CardContent className="space-y-6">
-                        <FormField
-                            control={form.control}
-                            name="containerCommand"
-                            render={({ field }) => (
-                                <FormItem>
-                                    <FormLabel>Command (optional)</FormLabel>
-                                    <FormControl>
-                                        <Input
-                                            placeholder="e.g., /bin/sh or minio"
-                                            {...field}
-                                            value={field.value as string | number | readonly string[] | undefined}
-                                        />
-                                    </FormControl>
-                                    <FormDescription>
-                                        Override the container&apos;s ENTRYPOINT.
-                                    </FormDescription>
-                                    <FormMessage />
-                                </FormItem>
-                            )}
-                        />
+                <TooltipProvider delayDuration={150}>
+                    <form action={(e) => form.handleSubmit((data) => {
+                        return formAction(data);
+                    })()}>
+                        <CardContent className="space-y-6">
+                            <div className="space-y-4">
+                                <div className="space-y-1">
+                                    <p className="text-sm font-medium">Runtime</p>
+                                    <p className="text-sm text-muted-foreground">
+                                        Leave these fields empty to keep the command and arguments from the container image.
+                                    </p>
+                                </div>
 
-                        <div className="space-y-2">
-                            <FormLabel>Arguments (optional)</FormLabel>
-                            <FormDescription className="mb-3">
-                                Override the container&apos;s CMD. Each argument should be a separate item.
-                            </FormDescription>
+                                <FormField
+                                    control={form.control}
+                                    name="containerCommand"
+                                    render={({ field }) => (
+                                        <FormItem>
+                                            <LabelWithHint hint="Overrides the image ENTRYPOINT. Leave empty to keep the command defined by the container image.">
+                                                Command
+                                            </LabelWithHint>
+                                            <FormControl>
+                                                <Input
+                                                    placeholder="e.g., /bin/sh or minio"
+                                                    {...field}
+                                                    value={field.value as string | number | readonly string[] | undefined}
+                                                />
+                                            </FormControl>
+                                            <FormMessage />
+                                        </FormItem>
+                                    )}
+                                />
 
-                            <div className="space-y-2">
-                                {fields.map((field, index) => (
-                                    <div key={field.id} className="flex gap-2 items-start">
-                                        <FormField
-                                            control={form.control}
-                                            name={`containerArgs.${index}.value`}
-                                            render={({ field }) => (
-                                                <FormItem className="flex-1">
-                                                    <FormControl>
-                                                        <Input
-                                                            placeholder={`Argument ${index + 1}`}
-                                                            {...field}
-                                                        />
-                                                    </FormControl>
-                                                    <FormMessage />
-                                                </FormItem>
-                                            )}
-                                        />
+                                <div className="space-y-3">
+                                    <LabelWithHint hint="Overrides the image CMD. Add one item per argument in the order the process should receive them.">
+                                        Arguments
+                                    </LabelWithHint>
+
+                                    <div className="space-y-2">
+                                        {fields.length === 0 && (
+                                            <div className="rounded-md border border-dashed px-3 py-2 text-sm text-muted-foreground">
+                                                No arguments configured.
+                                            </div>
+                                        )}
+
+                                        {fields.map((field, index) => (
+                                            <div key={field.id} className="flex items-start gap-2">
+                                                <FormField
+                                                    control={form.control}
+                                                    name={`containerArgs.${index}.value`}
+                                                    render={({ field }) => (
+                                                        <FormItem className="flex-1">
+                                                            <FormControl>
+                                                                <Input
+                                                                    placeholder={`Argument ${index + 1}`}
+                                                                    {...field}
+                                                                />
+                                                            </FormControl>
+                                                            <FormMessage />
+                                                        </FormItem>
+                                                    )}
+                                                />
+                                                <Button
+                                                    type="button"
+                                                    variant="ghost"
+                                                    size="icon"
+                                                    className="mt-0"
+                                                    onClick={() => remove(index)}
+                                                    disabled={readonly}
+                                                >
+                                                    <Trash2 className="h-4 w-4" />
+                                                </Button>
+                                            </div>
+                                        ))}
+                                    </div>
+
+                                    {!readonly && (
                                         <Button
                                             type="button"
-                                            variant="ghost"
-                                            size="icon"
-                                            className="mt-0"
-                                            onClick={() => remove(index)}
-                                            disabled={readonly}
+                                            variant="outline"
+                                            size="sm"
+                                            onClick={() => append({ value: '' })}
                                         >
-                                            <Trash2 className="h-4 w-4" />
+                                            <Plus className="mr-2 h-4 w-4" />
+                                            Add Argument
                                         </Button>
-                                    </div>
-                                ))}
+                                    )}
+                                </div>
                             </div>
 
-                            {!readonly && (
-                                <Button
-                                    type="button"
-                                    variant="outline"
-                                    size="sm"
-                                    className="mt-2"
-                                    onClick={() => append({ value: '' })}
-                                >
-                                    <Plus className="h-4 w-4 mr-2" />
-                                    Add Argument
-                                </Button>
-                            )}
-                        </div>
+                            <Separator />
 
-                        <div className="space-y-4">
-                            <div>
-                                <p className="text-sm font-medium">Security Context (optional)</p>
-                                <p className="text-sm text-muted-foreground mt-1">
-                                    Use this when your app requires specific user/group permissions or needs to run with a specific filesystem group for volume access.
-                                </p>
+                            <div className="space-y-4">
+                                <div className="space-y-1">
+                                    <p className="text-sm font-medium">Security Context</p>
+                                    <p className="text-sm text-muted-foreground">
+                                        Change these values only when your image, mounted volumes, or tooling require specific Linux permissions.
+                                    </p>
+                                </div>
+
+                                <div className="grid gap-4 md:grid-cols-3">
+                                    <FormField
+                                        control={form.control}
+                                        name="securityContextRunAsUser"
+                                        render={({ field }) => (
+                                            <FormItem>
+                                                <LabelWithHint hint="Linux user ID for the main container process. Maps to runAsUser in the Kubernetes securityContext.">
+                                                    Run As User
+                                                </LabelWithHint>
+                                                <FormControl>
+                                                    <Input
+                                                        type="number"
+                                                        placeholder="e.g., 1001"
+                                                        {...field}
+                                                        value={field.value ?? ''}
+                                                        onChange={e => field.onChange(e.target.value === '' ? null : Number(e.target.value))}
+                                                    />
+                                                </FormControl>
+                                                <FormMessage />
+                                            </FormItem>
+                                        )}
+                                    />
+                                    <FormField
+                                        control={form.control}
+                                        name="securityContextRunAsGroup"
+                                        render={({ field }) => (
+                                            <FormItem>
+                                                <LabelWithHint hint="Linux group ID for the main container process. Maps to runAsGroup in the Kubernetes securityContext.">
+                                                    Run As Group
+                                                </LabelWithHint>
+                                                <FormControl>
+                                                    <Input
+                                                        type="number"
+                                                        placeholder="e.g., 1001"
+                                                        {...field}
+                                                        value={field.value ?? ''}
+                                                        onChange={e => field.onChange(e.target.value === '' ? null : Number(e.target.value))}
+                                                    />
+                                                </FormControl>
+                                                <FormMessage />
+                                            </FormItem>
+                                        )}
+                                    />
+                                    <FormField
+                                        control={form.control}
+                                        name="securityContextFsGroup"
+                                        render={({ field }) => (
+                                            <FormItem>
+                                                <LabelWithHint hint="Supplemental group ID applied at pod level so mounted volumes can be owned and writable by that group. Maps to fsGroup in the Kubernetes securityContext.">
+                                                    FS Group
+                                                </LabelWithHint>
+                                                <FormControl>
+                                                    <Input
+                                                        type="number"
+                                                        placeholder="e.g., 1001"
+                                                        {...field}
+                                                        value={field.value ?? ''}
+                                                        onChange={e => field.onChange(e.target.value === '' ? null : Number(e.target.value))}
+                                                    />
+                                                </FormControl>
+                                                <FormMessage />
+                                            </FormItem>
+                                        )}
+                                    />
+                                </div>
+
+                                <FormField
+                                    control={form.control}
+                                    name="securityContextPrivileged"
+                                    render={({ field }) => (
+                                        <FormItem className="space-y-3 rounded-md border p-4">
+                                            <div className="flex items-start gap-4">
+                                                <FormControl>
+                                                    <Switch
+                                                        checked={field.value ?? false}
+                                                        onCheckedChange={field.onChange}
+                                                        disabled={readonly}
+                                                    />
+                                                </FormControl>
+                                                <div className="space-y-3 pt-0.5">
+                                                    <LabelWithHint
+                                                        hint={(
+                                                            <>
+                                                                <p>
+                                                                    Removes most container isolation. The container gets all Linux capabilities,
+                                                                    access to host devices, and can interact with the node almost like a root
+                                                                    process on the host.
+                                                                </p>
+                                                                <p className="mt-2">
+                                                                    If the container is compromised, it can affect the Kubernetes node and
+                                                                    other workloads. Use this only for workloads such as Docker-in-Docker
+                                                                    or low-level system tooling.
+                                                                </p>
+                                                            </>
+                                                        )}
+                                                    >
+                                                        Privileged Mode
+                                                    </LabelWithHint>
+
+                                                    {values.securityContextPrivileged && <Alert className="border-amber-200 bg-amber-50 text-amber-950">
+                                                        <AlertDescription>
+                                                            Enable this only if you fully understand the implications and risks.
+                                                        </AlertDescription>
+                                                    </Alert>}
+                                                </div>
+
+                                            </div>
+                                            <FormMessage />
+                                        </FormItem>
+                                    )}
+                                />
                             </div>
-                            <div className="grid grid-cols-3 gap-4">
-                                <FormField
-                                    control={form.control}
-                                    name="securityContextRunAsUser"
-                                    render={({ field }) => (
-                                        <FormItem>
-                                            <FormLabelWithQuestion hint="The UID to run the container process as. Corresponds to runAsUser in the Kubernetes pod securityContext.">
-                                                Run As User
-                                            </FormLabelWithQuestion>
-                                            <FormControl>
-                                                <Input
-                                                    type="number"
-                                                    placeholder="e.g., 1001"
-                                                    {...field}
-                                                    value={field.value ?? ''}
-                                                    onChange={e => field.onChange(e.target.value === '' ? null : Number(e.target.value))}
-                                                />
-                                            </FormControl>
-                                            <FormMessage />
-                                        </FormItem>
-                                    )}
-                                />
-                                <FormField
-                                    control={form.control}
-                                    name="securityContextRunAsGroup"
-                                    render={({ field }) => (
-                                        <FormItem>
-                                            <FormLabelWithQuestion hint="The GID to run the container process as. Corresponds to runAsGroup in the Kubernetes pod securityContext.">
-                                                Run As Group
-                                            </FormLabelWithQuestion>
-                                            <FormControl>
-                                                <Input
-                                                    type="number"
-                                                    placeholder="e.g., 1001"
-                                                    {...field}
-                                                    value={field.value ?? ''}
-                                                    onChange={e => field.onChange(e.target.value === '' ? null : Number(e.target.value))}
-                                                />
-                                            </FormControl>
-                                            <FormMessage />
-                                        </FormItem>
-                                    )}
-                                />
-                                <FormField
-                                    control={form.control}
-                                    name="securityContextFsGroup"
-                                    render={({ field }) => (
-                                        <FormItem>
-                                            <FormLabelWithQuestion hint="A special supplemental group applied to all containers in the pod. Volume ownership will be set to this GID. Corresponds to fsGroup in the Kubernetes pod securityContext.">
-                                                FS Group
-                                            </FormLabelWithQuestion>
-                                            <FormControl>
-                                                <Input
-                                                    type="number"
-                                                    placeholder="e.g., 1001"
-                                                    {...field}
-                                                    value={field.value ?? ''}
-                                                    onChange={e => field.onChange(e.target.value === '' ? null : Number(e.target.value))}
-                                                />
-                                            </FormControl>
-                                            <FormMessage />
-                                        </FormItem>
-                                    )}
-                                />
-                            </div>
-                            <FormField
-                                control={form.control}
-                                name="securityContextPrivileged"
-                                render={({ field }) => (
-                                    <FormItem className="flex flex-row items-start space-x-3 space-y-0 rounded-md border p-4">
-                                        <FormControl>
-                                            <Checkbox
-                                                checked={field.value}
-                                                onCheckedChange={field.onChange}
-                                                disabled={readonly}
-                                            />
-                                        </FormControl>
-                                        <div className="space-y-1 leading-none">
-                                            <FormLabel>Privileged Mode</FormLabel>
-                                            <FormDescription>
-                                                Run this container in privileged mode. This grants full access to the host&apos;s devices and kernel capabilities. Required for Docker-in-Docker (DinD) workloads such as CI/CD runners.
-                                            </FormDescription>
-                                        </div>
-                                    </FormItem>
-                                )}
-                            />
-                        </div>
-                    </CardContent>
-                    {!readonly && (
-                        <CardFooter className="gap-4">
-                            <SubmitButton>Save</SubmitButton>
-                            <p className="text-red-500">{state?.message}</p>
-                        </CardFooter>
-                    )}
-                </form>
+                        </CardContent>
+                        {!readonly && (
+                            <CardFooter className="gap-4">
+                                <SubmitButton>Save</SubmitButton>
+                                <p className="text-red-500">{state?.message}</p>
+                            </CardFooter>
+                        )}
+                    </form>
+                </TooltipProvider>
             </Form>
         </Card>
     );

--- a/src/app/project/app/[appId]/general/app-container-config.tsx
+++ b/src/app/project/app/[appId]/general/app-container-config.tsx
@@ -3,6 +3,7 @@
 import { SubmitButton } from "@/components/custom/submit-button";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from "@/components/ui/card";
+import { Checkbox } from "@/components/ui/checkbox";
 import { Form, FormControl, FormDescription, FormField, FormItem, FormLabel, FormMessage } from "@/components/ui/form";
 import { FormUtils } from "@/frontend/utils/form.utilts";
 import { zodResolver } from "@hookform/resolvers/zod";
@@ -38,6 +39,7 @@ export default function GeneralAppContainerConfig({ app, readonly }: {
             securityContextRunAsUser: app.securityContextRunAsUser ?? undefined,
             securityContextRunAsGroup: app.securityContextRunAsGroup ?? undefined,
             securityContextFsGroup: app.securityContextFsGroup ?? undefined,
+            securityContextPrivileged: app.securityContextPrivileged ?? false,
         },
         disabled: readonly,
     });
@@ -220,6 +222,27 @@ export default function GeneralAppContainerConfig({ app, readonly }: {
                                     )}
                                 />
                             </div>
+                            <FormField
+                                control={form.control}
+                                name="securityContextPrivileged"
+                                render={({ field }) => (
+                                    <FormItem className="flex flex-row items-start space-x-3 space-y-0 rounded-md border p-4">
+                                        <FormControl>
+                                            <Checkbox
+                                                checked={field.value}
+                                                onCheckedChange={field.onChange}
+                                                disabled={readonly}
+                                            />
+                                        </FormControl>
+                                        <div className="space-y-1 leading-none">
+                                            <FormLabel>Privileged Mode</FormLabel>
+                                            <FormDescription>
+                                                Run this container in privileged mode. This grants full access to the host&apos;s devices and kernel capabilities. Required for Docker-in-Docker (DinD) workloads such as CI/CD runners.
+                                            </FormDescription>
+                                        </div>
+                                    </FormItem>
+                                )}
+                            />
                         </div>
                     </CardContent>
                     {!readonly && (

--- a/src/server/services/deployment.service.ts
+++ b/src/server/services/deployment.service.ts
@@ -139,6 +139,7 @@ class DeploymentService {
                                 imagePullPolicy: 'Always',
                                 ...(app.containerCommand ? { command: [app.containerCommand] } : {}),
                                 ...(app.containerArgs ? { args: JSON.parse(app.containerArgs) } : {}),
+                                ...(app.securityContextPrivileged ? { securityContext: { privileged: true } } : {}),
                                 ...(envVars.length > 0 ? { env: envVars } : {}),
                                 ...(allVolumeMounts.length > 0 ? { volumeMounts: allVolumeMounts } : {}),
                             }

--- a/src/shared/model/app-container-config.model.ts
+++ b/src/shared/model/app-container-config.model.ts
@@ -9,6 +9,7 @@ export const appContainerConfigZodModel = z.object({
   securityContextRunAsUser: stringToOptionalNumber,
   securityContextRunAsGroup: stringToOptionalNumber,
   securityContextFsGroup: stringToOptionalNumber,
+  securityContextPrivileged: z.boolean().default(false),
 });
 
 export type AppContainerConfigModel = z.infer<typeof appContainerConfigZodModel>;

--- a/src/shared/model/generated-zod/app.ts
+++ b/src/shared/model/generated-zod/app.ts
@@ -16,6 +16,7 @@ export const AppModel = z.object({
   securityContextRunAsUser: z.number().int().nullish(),
   securityContextRunAsGroup: z.number().int().nullish(),
   securityContextFsGroup: z.number().int().nullish(),
+  securityContextPrivileged: z.boolean().nullish(),
   gitUrl: z.string().nullish(),
   gitBranch: z.string().nullish(),
   gitUsername: z.string().nullish(),


### PR DESCRIPTION
 ## Summary
  - Adds a "Privileged Mode" checkbox in the Container Configuration section under Security Context
  - When enabled, sets `securityContext.privileged: true` on the Kubernetes container spec
  - Required for Docker-in-Docker workloads such as CI/CD runners (Gitea Actions, GitLab Runner, etc.)

  ## Changes
  - `prisma/schema.prisma`: Add `securityContextPrivileged` field to App model
  - `migration.sql`: `ALTER TABLE ADD COLUMN` migration
  - `app-container-config.model.ts`: Add field to Zod validation schema
  - `app-container-config.tsx`: Add checkbox UI with description
  - `actions.ts`: Persist field on save
  - `deployment.service.ts`: Set `securityContext.privileged` on container spec

  ## Test plan
  - [x] `yarn test` — no regressions (existing failures are unrelated)
  - [x] TypeScript type check passes
  - [x] Deploy app with privileged mode enabled, verify pod has `securityContext.privileged: true`
  - [x] Deploy app without privileged mode, verify no securityContext is set