### PR TITLE
chore: Update cert-manager with helm

### DIFF
--- a/setup/setup-canary.sh
+++ b/setup/setup-canary.sh
@@ -114,9 +114,14 @@ if ! grep -q 'dm_crypt' /etc/modules; then
   echo "dm_crypt" | sudo tee -a /etc/modules
 fi
 
-# Installation of k3s
-#curl -sfL https://get.k3s.io | INSTALL_K3S_EXEC="--node-ip=192.168.1.2 --advertise-address=192.168.1.2 --node-external-ip=188.245.236.232 --flannel-iface=enp7s0" INSTALL_K3S_VERSION="v1.31.3+k3s1" sh -
+# Installation of helm
+sudo apt-get install apt-transport-https gpg --yes
+curl -fsSL https://packages.buildkite.com/helm-linux/helm-debian/gpgkey | gpg --dearmor | sudo tee /usr/share/keyrings/helm.gpg >/dev/null
+echo "deb [signed-by=/usr/share/keyrings/helm.gpg] https://packages.buildkite.com/helm-linux/helm-debian/any/ any main" | sudo tee /etc/apt/sources.list.d/helm-stable-debian.list
+sudo apt-get update
+sudo apt-get install helm
 
+# Installation of k3s
 echo "Installing k3s with --flannel-iface=$selected_iface"
 curl -sfL https://get.k3s.io | INSTALL_K3S_EXEC="--flannel-iface=$selected_iface" INSTALL_K3S_VERSION="$K3S_VERSION" sh -
 # Todo: Check for Ready node, takes ~30 seconds
@@ -131,10 +136,21 @@ echo "Waiting for Longhorn to start..."
 wait_until_all_pods_running
 
 # Installation of Cert-Manager
-sudo kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.16.1/cert-manager.yaml
+
+# Installation of Cert-Manager
+sudo helm --kubeconfig /etc/rancher/k3s/k3s.yaml install \
+  cert-manager oci://quay.io/jetstack/charts/cert-manager \
+  --version v1.18.6 \
+  --namespace cert-manager \
+  --create-namespace \
+  --set crds.enabled=true
+
 echo "Waiting for Cert-Manager to start..."
 wait_until_all_pods_running
 sudo kubectl -n cert-manager get pod
+
+# Use this for manually upgrading cert-manager using helm:
+# helm upgrade --reset-then-reuse-values --version <version> <release_name> oci://quay.io/jetstack/charts/cert-manager
 
 # Checking installation of Longhorn
 sudo curl -sSfL "https://raw.githubusercontent.com/longhorn/longhorn/${LONGHORN_VERSION}/scripts/environment_check.sh" | sudo bash

--- a/setup/setup.sh
+++ b/setup/setup.sh
@@ -115,6 +115,13 @@ if ! grep -q 'dm_crypt' /etc/modules; then
   echo "dm_crypt" | sudo tee -a /etc/modules
 fi
 
+# Installation of helm
+sudo apt-get install apt-transport-https gpg --yes
+curl -fsSL https://packages.buildkite.com/helm-linux/helm-debian/gpgkey | gpg --dearmor | sudo tee /usr/share/keyrings/helm.gpg >/dev/null
+echo "deb [signed-by=/usr/share/keyrings/helm.gpg] https://packages.buildkite.com/helm-linux/helm-debian/any/ any main" | sudo tee /etc/apt/sources.list.d/helm-stable-debian.list
+sudo apt-get update
+sudo apt-get install helm
+
 # Installation of k3s
 #curl -sfL https://get.k3s.io | INSTALL_K3S_EXEC="--node-ip=192.168.1.2 --advertise-address=192.168.1.2 --node-external-ip=188.245.236.232 --flannel-iface=enp7s0" INSTALL_K3S_VERSION="v1.31.3+k3s1" sh -
 
@@ -132,10 +139,19 @@ echo "Waiting for Longhorn to start..."
 wait_until_all_pods_running
 
 # Installation of Cert-Manager
-sudo kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.16.1/cert-manager.yaml
+sudo helm --kubeconfig /etc/rancher/k3s/k3s.yaml install \
+  cert-manager oci://quay.io/jetstack/charts/cert-manager \
+  --version v1.18.6 \
+  --namespace cert-manager \
+  --create-namespace \
+  --set crds.enabled=true
+
 echo "Waiting for Cert-Manager to start..."
 wait_until_all_pods_running
 sudo kubectl -n cert-manager get pod
+
+# Use this for manually upgrading cert-manager using helm:
+# helm upgrade --reset-then-reuse-values --version <version> <release_name> oci://quay.io/jetstack/charts/cert-manager
 
 # Use this for checking installation of Longhorn
 # sudo curl -sSfL https://raw.githubusercontent.com/longhorn/longhorn/v1.7.2/scripts/environment_check.sh | sudo bash

--- a/setup/setup.sh
+++ b/setup/setup.sh
@@ -123,8 +123,6 @@ sudo apt-get update
 sudo apt-get install helm
 
 # Installation of k3s
-#curl -sfL https://get.k3s.io | INSTALL_K3S_EXEC="--node-ip=192.168.1.2 --advertise-address=192.168.1.2 --node-external-ip=188.245.236.232 --flannel-iface=enp7s0" INSTALL_K3S_VERSION="v1.31.3+k3s1" sh -
-
 echo "Installing k3s with --flannel-iface=$selected_iface"
 curl -sfL https://get.k3s.io | INSTALL_K3S_EXEC="--flannel-iface=$selected_iface" INSTALL_K3S_VERSION="$K3S_VERSION" sh -
 # Todo: Check for Ready node, takes ~30 seconds


### PR DESCRIPTION
## Summary

Version of cert-manager pulled up to most recent release of closest minor version - v1.18.6

Changelog: https://cert-manager.io/docs/releases/release-notes/release-notes-1.18/
Most notable: 

> New default private key rotation policy for Certificate resources.
> The default private key rotation policy for Certificate resources was
> changed to `Always` in cert-manager >= v1.18.0.

In order to make cert-manager easier to upgrade in the future or for manual upgrades by the user, 
switched to using helm instead of directly applying the resource definitions. 
See comment line for a way to upgrade to a newer version, if need be. 

APT was chosen to install helm, as every other dependency except k3s itself was also installed via package management. 


## Changes
* Upgrade stale version of cert-manager to v1.18.6 in setup-script
* Use helm for this instead of applying the resource definitions directly
* This also includes the CRDs that now can also be upgraded via helm if they would change
* Repo points to new, somehow [not properly documented source](https://github.com/helm/helm-www/pull/1750/changes) for the official helm-chart... 

## Test plan
Since this only touches the setup script and not the quickstack service, I've spun up VMs and tested it against vanilla instances with distros that (I think?) should be compatible with the install procedure: 

- [x] Ubuntu 24.04
- [x] Ubuntu 22.04
- [x] Debian 13

After a few tweaks this now runs absolutely perfectly. 
Needs quite a bit of RAM though to even complete setup :wink: 


closes #76