### PR TITLE
feat: add Chisel app template and SVG icon for service availability

### DIFF
--- a/public/template-icons/chisel.svg
+++ b/public/template-icons/chisel.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="128" height="128" viewBox="0 0 24 24" fill="none" stroke="#3b82f6" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M4 13a8 8 0 0 1 16 0"/>
+  <path d="M7 13a5 5 0 0 1 10 0"/>
+  <line x1="12" y1="13" x2="12" y2="20"/>
+  <circle cx="12" cy="13" r="1" fill="#3b82f6"/>
+</svg>

--- a/src/server/services/app.service.ts
+++ b/src/server/services/app.service.ts
@@ -185,6 +185,7 @@ class AppService {
         // for new objects, make sure some params are optional, wich will be created by prisma
         const optionalParam = z.object({
             id: z.string().optional(),
+            appId: z.string().optional(),
             createdAt: z.date().optional(),
             updatedAt: z.date().optional(),
         });

--- a/src/shared/templates/all.templates.ts
+++ b/src/shared/templates/all.templates.ts
@@ -44,6 +44,7 @@ import { openwebuiAppTemplate, postCreateOpenwebuiAppTemplate } from "./apps/ope
 import { AppExtendedModel } from "../model/app-extended.model";
 import { tikaAppTemplate } from "./apps/tika.template";
 import { libredeskAppTemplate, postCreateLibredeskAppTemplate } from "./apps/libredesk.template";
+import { chiselAppTemplate, postCreateChiselAppTemplate } from "./apps/chisel.template";
 
 
 export const databaseTemplates: AppTemplateModel[] = [
@@ -95,7 +96,8 @@ export const appTemplates: AppTemplateModel[] = [
     duplicatiAppTemplate,
     openwebuiAppTemplate,
     tikaAppTemplate,
-    libredeskAppTemplate
+    libredeskAppTemplate,
+    chiselAppTemplate
 ];
 
 export const postCreateTemplateFunctions: Map<string, (createdApps: AppExtendedModel[]) => Promise<AppExtendedModel[]>> = new Map([
@@ -105,6 +107,7 @@ export const postCreateTemplateFunctions: Map<string, (createdApps: AppExtendedM
     [docmostAppTemplate.name, postCreateDocmostAppTemplate],
     [duplicatiAppTemplate.name, postCreateDuplicatiAppTemplate],
     [n8nAppTemplate.name, postCreateN8NAppTemplate],
+    [chiselAppTemplate.name, postCreateChiselAppTemplate],
 ]);
 
 

--- a/src/shared/templates/apps/chisel.template.ts
+++ b/src/shared/templates/apps/chisel.template.ts
@@ -1,0 +1,82 @@
+import { Constants } from "@/shared/utils/constants";
+import { AppTemplateContentModel, AppTemplateModel } from "../../model/app-template.model";
+import { AppExtendedModel } from "@/shared/model/app-extended.model";
+import crypto from "crypto";
+
+export function getChiselAppTemplate(config?: {
+    appName?: string,
+    username?: string,
+    password?: string
+}): AppTemplateContentModel {
+    return {
+        inputSettings: [
+            {
+                key: "containerImageSource",
+                label: "Container Image",
+                value: "jpillora/chisel:latest",
+                isEnvVar: false,
+                randomGeneratedIfEmpty: false,
+            },
+            {
+                key: "CHISEL_USER",
+                label: "Username",
+                value: config?.username || "chisel",
+                isEnvVar: true,
+                randomGeneratedIfEmpty: false,
+            },
+            {
+                key: "CHISEL_PASSWORD",
+                label: "Password",
+                value: config?.password || "",
+                isEnvVar: true,
+                randomGeneratedIfEmpty: true,
+            },
+        ],
+        appModel: {
+            name: config?.appName || "Chisel Tunnel",
+            appType: 'APP',
+            sourceType: 'CONTAINER',
+            containerImageSource: "",
+            replicas: 1,
+            ingressNetworkPolicy: Constants.DEFAULT_INGRESS_NETWORK_POLICY_APPS,
+            egressNetworkPolicy: Constants.DEFAULT_EGRESS_NETWORK_POLICY_APPS,
+            envVars: ``,
+            useNetworkPolicy: false,
+            healthCheckPeriodSeconds: Constants.DEFAULT_HEALTH_CHECK_PERIOD_SECONDS,
+            healthCheckTimeoutSeconds: Constants.DEFAULT_HEALTH_CHECK_TIMEOUT_SECONDS,
+            healthCheckFailureThreshold: Constants.DEFAULT_HEALTH_CHECK_FAILURE_THRESHOLD,
+            containerArgs: '["server", "--keyfile", "/etc/chisel/chisel.key", "--auth", "$(CHISEL_USER):$(CHISEL_PASSWORD)", "--reverse"]',
+        },
+        appDomains: [],
+        appVolumes: [],
+        appFileMounts: [],
+        appPorts: [{
+            port: 8080,
+        }],
+    };
+}
+
+export const chiselAppTemplate: AppTemplateModel = {
+    name: "Chisel Tunnel",
+    iconName: 'chisel.svg',
+    templates: [
+        getChiselAppTemplate()
+    ],
+};
+
+export const postCreateChiselAppTemplate = async (createdApps: AppExtendedModel[]): Promise<AppExtendedModel[]> => {
+    const app = createdApps[0];
+
+    const { privateKey } = crypto.generateKeyPairSync('ec', {
+        namedCurve: 'P-256',
+        privateKeyEncoding: { type: 'sec1', format: 'pem' },
+        publicKeyEncoding: { type: 'spki', format: 'pem' },
+    });
+
+    app.appFileMounts.push({
+        containerMountPath: '/etc/chisel/chisel.key',
+        content: privateKey,
+    } as any);
+
+    return [app];
+};

--- a/src/shared/templates/apps/chisel.template.ts
+++ b/src/shared/templates/apps/chisel.template.ts
@@ -41,7 +41,7 @@ export function getChiselAppTemplate(config?: {
             ingressNetworkPolicy: Constants.DEFAULT_INGRESS_NETWORK_POLICY_APPS,
             egressNetworkPolicy: Constants.DEFAULT_EGRESS_NETWORK_POLICY_APPS,
             envVars: ``,
-            useNetworkPolicy: false,
+            useNetworkPolicy: true,
             healthCheckPeriodSeconds: Constants.DEFAULT_HEALTH_CHECK_PERIOD_SECONDS,
             healthCheckTimeoutSeconds: Constants.DEFAULT_HEALTH_CHECK_TIMEOUT_SECONDS,
             healthCheckFailureThreshold: Constants.DEFAULT_HEALTH_CHECK_FAILURE_THRESHOLD,


### PR DESCRIPTION
## Summary

  - Add Chisel Tunnel as a new app template, enabling users to securely access project services (MongoDB, Redis, Postgres, etc.) from their local machine via TCP-over-WebSocket tunneling
  - Chisel runs as a regular app within a project and is routed through Traefik via a domain — no additional ports need to be opened on the server
  - Authentication is handled via `--auth` flag with auto-generated credentials (username/password visible in Environment tab)

  ## How it works

  1. Deploy the Chisel Tunnel template in a project alongside other services
  2. Assign a domain (e.g. `tunnel.example.com`) pointing to port 8080
  3. Connect locally:
     ```bash
     chisel client --auth chisel:<password> https://tunnel.example.com \
       27017:svc-app-<mongo-id>:27017 \
       6379:svc-app-<redis-id>:6379
  4. Access services on localhost as if running locally

  Test plan

  - Deploy Chisel Tunnel template in a project
  - Verify container starts with correct --auth args
  - Assign a domain and verify Traefik routes WebSocket traffic
  - Connect with chisel client and verify TCP tunneling to other project services
