### PR TITLE
feat: update default K3s and Longhorn production install versions to latest compatible releases

### DIFF
--- a/setup/k3s-versions.json
+++ b/setup/k3s-versions.json
@@ -1,10 +1,18 @@
 {
-    "prodInstallVersion": "v1.31.3+k3s1",
+    "prodInstallVersion": "v1.33.4+k3s1",
     "canaryInstallVersion": "v1.33.4+k3s1",
     "prod": [
         {
             "version": "v1.31",
             "channelUrl": "https://update.k3s.io/v1-release/channels/v1.31"
+        },
+        {
+            "version": "v1.32",
+            "channelUrl": "https://update.k3s.io/v1-release/channels/v1.32"
+        },
+        {
+            "version": "v1.33",
+            "channelUrl": "https://update.k3s.io/v1-release/channels/v1.33"
         }
     ],
     "canary": [

--- a/setup/longhorn-versions.json
+++ b/setup/longhorn-versions.json
@@ -1,10 +1,22 @@
 {
-    "prodInstallVersion": "v1.7.2",
+    "prodInstallVersion": "v1.10.1",
     "canaryInstallVersion": "v1.10.1",
     "prod": [
         {
             "version": "v1.7.2",
             "yamlUrl": "https://raw.githubusercontent.com/longhorn/longhorn/v1.7.2/deploy/longhorn.yaml"
+        },
+        {
+            "version": "v1.8.2",
+            "yamlUrl": "https://raw.githubusercontent.com/longhorn/longhorn/v1.8.2/deploy/longhorn.yaml"
+        },
+        {
+            "version": "v1.9.2",
+            "yamlUrl": "https://raw.githubusercontent.com/longhorn/longhorn/v1.9.2/deploy/longhorn.yaml"
+        },
+        {
+            "version": "v1.10.1",
+            "yamlUrl": "https://raw.githubusercontent.com/longhorn/longhorn/v1.10.1/deploy/longhorn.yaml"
         }
     ],
     "canary": [


### PR DESCRIPTION
This pull request updates the supported versions for both K3s and Longhorn in the setup configuration files.

**K3s Version Updates:**
- Updated `prodInstallVersion` to `v1.33.4+k3s1`, matching the `canaryInstallVersion`.
- Added new production versions `v1.32` and `v1.33` to the `prod` list, each with their corresponding channel URLs.

**Longhorn Version Updates:**
- Updated `prodInstallVersion` to `v1.10.1`, matching the `canaryInstallVersion`.
- Added new production versions `v1.8.2`, `v1.9.2`, and `v1.10.1` to the `prod` list, each with their respective deployment YAML URLs.