### PR TITLE
Feat/placement options for build containers in cluster

### DIFF
--- a/src/app/project/app/[appId]/overview/deployments.tsx
+++ b/src/app/project/app/[appId]/overview/deployments.tsx
@@ -84,6 +84,7 @@ export default function BuildsTab({
                         ['status', 'Status', true, (item) => <DeploymentStatusBadge>{item.status}</DeploymentStatusBadge>],
                         ["startTime", "Started At", true, (item) => formatDateTime(item.createdAt)],
                         ['gitCommit', 'Git Commit', true, (item) => <ShortCommitHash>{item.gitCommit}</ShortCommitHash>],
+                        ['gitCommitMessage', 'Commit Message', true, (item) => <span className="text-muted-foreground text-sm">{item.gitCommitMessage ?? ''}</span>],
                     ]}
                         data={appBuilds}
                         hideSearchBar={true}

--- a/src/app/settings/server/actions.ts
+++ b/src/app/settings/server/actions.ts
@@ -32,6 +32,46 @@ import { TraefikIpPropagationStatus } from "@/shared/model/traefik-ip-propagatio
 import k3sUpdateService from "@/server/services/upgrade-services/k3s-update.service";
 import longhornUpdateService from "@/server/services/upgrade-services/longhorn-update.service";
 import longhornUiService from "@/server/services/longhorn-ui.service";
+import { BuildSettingsModel, buildSettingsZodModel } from "@/shared/model/build-settings.model";
+
+export const saveBuildSettings = async (prevState: any, inputData: BuildSettingsModel) =>
+  saveFormAction(inputData, buildSettingsZodModel, async (validatedData) => {
+    await getAdminUserSession();
+
+    const saveOrDelete = async (key: string, value: string | number | null | undefined) => {
+      if (value !== null && value !== undefined && value !== '') {
+        await paramService.save({ name: key, value: String(value) });
+      } else {
+        await paramService.deleteByNameIfExists(key);
+      }
+    };
+
+    // Resource limits only apply when using k3s native scheduling
+    if (validatedData.buildNode === Constants.BUILD_NODE_K3S_NATIVE_VALUE) {
+      await saveOrDelete(ParamService.BUILD_MEMORY_LIMIT, validatedData.memoryLimit);
+      await saveOrDelete(ParamService.BUILD_MEMORY_RESERVATION, validatedData.memoryReservation);
+      await saveOrDelete(ParamService.BUILD_CPU_LIMIT, validatedData.cpuLimit);
+      await saveOrDelete(ParamService.BUILD_CPU_RESERVATION, validatedData.cpuReservation);
+    } else {
+      await paramService.deleteByNameIfExists(ParamService.BUILD_MEMORY_LIMIT);
+      await paramService.deleteByNameIfExists(ParamService.BUILD_MEMORY_RESERVATION);
+      await paramService.deleteByNameIfExists(ParamService.BUILD_CPU_LIMIT);
+      await paramService.deleteByNameIfExists(ParamService.BUILD_CPU_RESERVATION);
+    }
+    await saveOrDelete(ParamService.BUILD_NODE, validatedData.buildNode);
+  });
+
+export const getBuildSettings = async (): Promise<BuildSettingsModel> => {
+  await getAdminUserSession();
+  const [memoryLimit, memoryReservation, cpuLimit, cpuReservation, buildNode] = await Promise.all([
+    paramService.getNumber(ParamService.BUILD_MEMORY_LIMIT),
+    paramService.getNumber(ParamService.BUILD_MEMORY_RESERVATION),
+    paramService.getNumber(ParamService.BUILD_CPU_LIMIT),
+    paramService.getNumber(ParamService.BUILD_CPU_RESERVATION),
+    paramService.getString(ParamService.BUILD_NODE),
+  ]);
+  return { memoryLimit, memoryReservation, cpuLimit, cpuReservation, buildNode };
+};
 
 export const setNodeStatus = async (nodeName: string, schedulable: boolean) =>
   simpleAction(async () => {

--- a/src/app/settings/server/page.tsx
+++ b/src/app/settings/server/page.tsx
@@ -18,7 +18,9 @@ import { TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import QuickStackMaintenanceSettings from "./qs-maintenance-settings";
 import podService from "@/server/services/pod.service";
 import { ServerSettingsTabs } from "./server-settings-tabs";
-import { Settings, Network, HardDrive, Rocket, Wrench } from "lucide-react";
+import { Settings, Network, HardDrive, Rocket, Wrench, Hammer } from "lucide-react";
+import QsBuildSettings from "./qs-build-settings";
+import { getBuildSettings } from "./actions";
 import quickStackUpdateService from "@/server/services/qs-update.service";
 import { ScrollArea, ScrollBar } from "@/components/ui/scroll-area";
 import clusterService from "@/server/services/cluster.service";
@@ -57,13 +59,15 @@ export default async function ProjectPage({
         traefikStatus,
         qsPodInfos,
         newVersionInfo,
-        nodeInfo
+        nodeInfo,
+        buildSettings
     ] = await Promise.all([
         s3TargetService.getAll(),
         traefikService.getStatus(),
         podService.getPodsForApp(Constants.QS_NAMESPACE, Constants.QS_APP_NAME),
         quickStackUpdateService.getNewVersionInfo(),
-        clusterService.getNodeInfo()
+        clusterService.getNodeInfo(),
+        getBuildSettings()
     ]);
 
     const qsPodInfo = qsPodInfos.find(p => !!p);
@@ -90,6 +94,7 @@ export default async function ProjectPage({
                         <TabsTrigger value="general"><Settings className="mr-2 h-4 w-4" />General</TabsTrigger>
                         <TabsTrigger value="networking"><Network className="mr-2 h-4 w-4" />Networking / Traefik</TabsTrigger>
                         <TabsTrigger value="storage"><HardDrive className="mr-2 h-4 w-4" />Storage & Backups</TabsTrigger>
+                        <TabsTrigger value="builds"><Hammer className="mr-2 h-4 w-4" />Builds</TabsTrigger>
                         <TabsTrigger value="cluster"><Network className="mr-2 h-4 w-4" />Cluster</TabsTrigger>
                         <TabsTrigger value="updates"><Rocket className="mr-2 h-4 w-4" />Updates {newVersionInfo && <div className="h-2 w-2 ml-2 rounded-full bg-orange-500 animate-pulse" />}</TabsTrigger>
                         <TabsTrigger value="maintenance"><Wrench className="mr-2 h-4 w-4" />Maintenance</TabsTrigger>
@@ -115,6 +120,12 @@ export default async function ProjectPage({
                         <QuickStackRegistrySettings registryStorageLocation={regitryStorageLocation!} s3Targets={s3Targets} />
                         <QuickStackSystemBackupSettings systemBackupLocation={systemBackupLocation!} s3Targets={s3Targets} />
                         <LonghornUiToggle />
+                    </div>
+                </TabsContent>
+
+                <TabsContent value="builds" className="space-y-4">
+                    <div className="grid gap-6">
+                        <QsBuildSettings buildSettings={buildSettings} nodes={nodeInfo} />
                     </div>
                 </TabsContent>
 

--- a/src/app/settings/server/qs-build-settings.tsx
+++ b/src/app/settings/server/qs-build-settings.tsx
@@ -1,0 +1,184 @@
+'use client';
+
+import { SubmitButton } from "@/components/custom/submit-button";
+import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from "@/components/ui/card";
+import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from "@/components/ui/form";
+import { FormUtils } from "@/frontend/utils/form.utilts";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useForm } from "react-hook-form";
+import { useFormState } from "react-dom";
+import { ServerActionResult } from "@/shared/model/server-action-error-return.model";
+import { Input } from "@/components/ui/input";
+import { BuildSettingsModel, buildSettingsZodModel } from "@/shared/model/build-settings.model";
+import { useEffect } from "react";
+import { toast } from "sonner";
+import { saveBuildSettings } from "./actions";
+import { NodeInfoModel } from "@/shared/model/node-info.model";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { AlertCircle } from "lucide-react";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { Constants } from "@/shared/utils/constants";
+
+export default function QsBuildSettings({
+    buildSettings,
+    nodes,
+}: {
+    buildSettings: BuildSettingsModel;
+    nodes: NodeInfoModel[];
+}) {
+    const form = useForm<BuildSettingsModel>({
+        resolver: zodResolver(buildSettingsZodModel),
+        defaultValues: {
+            ...buildSettings,
+            buildNode: buildSettings.buildNode || Constants.BUILD_AUTO_NODE_VALUE,
+        },
+    });
+
+    const [state, formAction] = useFormState(
+        (state: ServerActionResult<any, any>, payload: BuildSettingsModel) => saveBuildSettings(state, payload),
+        FormUtils.getInitialFormState<typeof buildSettingsZodModel>()
+    );
+
+    useEffect(() => {
+        if (state.status === 'success') {
+            toast.success('Build settings saved.');
+        }
+        FormUtils.mapValidationErrorsToForm<typeof buildSettingsZodModel>(state, form);
+    }, [state]);
+
+    const watchedBuildNode = form.watch('buildNode');
+    const isK3sNative = watchedBuildNode === Constants.BUILD_NODE_K3S_NATIVE_VALUE;
+    const showReservationAlert = !buildSettings.memoryReservation || !buildSettings.cpuReservation;
+
+    return (
+        <Card>
+            <CardHeader>
+                <CardTitle>Build Container Settings</CardTitle>
+                <CardDescription>
+                    Configure global resource limits and node placement for all build containers.
+                </CardDescription>
+            </CardHeader>
+            <Form {...form}>
+                <form action={(e) => form.handleSubmit((data) => {
+                    const payload = {
+                        ...data,
+                        buildNode: data.buildNode === Constants.BUILD_AUTO_NODE_VALUE || data.buildNode === '' ? null : data.buildNode,
+                    };
+                    return formAction(payload);
+                })()}>
+                    <CardContent className="space-y-6">
+
+                        <FormField
+                            control={form.control}
+                            name="buildNode"
+                            render={({ field }) => (
+                                <FormItem>
+                                    <FormLabel>Build Node (optional)</FormLabel>
+                                    <Select
+                                        onValueChange={field.onChange}
+                                        value={field.value || Constants.BUILD_AUTO_NODE_VALUE}
+                                    >
+                                        <FormControl>
+                                            <SelectTrigger>
+                                                <SelectValue placeholder="Auto (node with most available resources)" />
+                                            </SelectTrigger>
+                                        </FormControl>
+                                        <SelectContent>
+                                            <SelectItem value={Constants.BUILD_AUTO_NODE_VALUE}>
+                                                Auto (node with most available resources)
+                                            </SelectItem>
+                                            <SelectItem value={Constants.BUILD_NODE_K3S_NATIVE_VALUE}>
+                                                k3s native
+                                            </SelectItem>
+                                            {nodes.map((node) => (
+                                                <SelectItem
+                                                    key={node.name}
+                                                    value={node.name}
+                                                    disabled={!node.schedulable}
+                                                >
+                                                    {node.name}{!node.schedulable ? ' (not schedulable)' : ''}
+                                                </SelectItem>
+                                            ))}
+                                        </SelectContent>
+                                    </Select>
+                                    <FormMessage />
+                                </FormItem>
+                            )}
+                        />
+                        {isK3sNative && showReservationAlert && (
+                            <Alert>
+                                <AlertCircle className="h-4 w-4" />
+                                <AlertTitle>Reservations not configured</AlertTitle>
+                                <AlertDescription>
+                                    No CPU and/or memory reservations are set. Setting them is recommended for optimal build container scheduling.
+                                </AlertDescription>
+                            </Alert>
+                        )}
+
+                        {isK3sNative && <div className="grid grid-cols-2 gap-4">
+                            <FormField
+                                control={form.control}
+                                name="memoryLimit"
+                                render={({ field }) => (
+                                    <FormItem>
+                                        <FormLabel>Memory Limit (MB)</FormLabel>
+                                        <FormControl>
+                                            <Input type="number" {...field} value={field.value as string | number | undefined ?? ''} />
+                                        </FormControl>
+                                        <FormMessage />
+                                    </FormItem>
+                                )}
+                            />
+
+                            <FormField
+                                control={form.control}
+                                name="memoryReservation"
+                                render={({ field }) => (
+                                    <FormItem>
+                                        <FormLabel>Memory Reservation (MB)</FormLabel>
+                                        <FormControl>
+                                            <Input type="number" {...field} value={field.value as string | number | undefined ?? ''} />
+                                        </FormControl>
+                                        <FormMessage />
+                                    </FormItem>
+                                )}
+                            />
+
+                            <FormField
+                                control={form.control}
+                                name="cpuLimit"
+                                render={({ field }) => (
+                                    <FormItem>
+                                        <FormLabel>CPU Limit (m)</FormLabel>
+                                        <FormControl>
+                                            <Input type="number" {...field} value={field.value as string | number | undefined ?? ''} />
+                                        </FormControl>
+                                        <FormMessage />
+                                    </FormItem>
+                                )}
+                            />
+
+                            <FormField
+                                control={form.control}
+                                name="cpuReservation"
+                                render={({ field }) => (
+                                    <FormItem>
+                                        <FormLabel>CPU Reservation (m)</FormLabel>
+                                        <FormControl>
+                                            <Input type="number" {...field} value={field.value as string | number | undefined ?? ''} />
+                                        </FormControl>
+                                        <FormMessage />
+                                    </FormItem>
+                                )}
+                            />
+                        </div>}
+                    </CardContent>
+                    <CardFooter className="gap-4">
+                        <SubmitButton>Save</SubmitButton>
+                        <p className="text-red-500">{state?.message}</p>
+                    </CardFooter>
+                </form>
+            </Form>
+        </Card>
+    );
+}

--- a/src/server/services/app.service.ts
+++ b/src/server/services/app.service.ts
@@ -32,11 +32,11 @@ class AppService {
 
             if (app.sourceType === 'GIT') {
                 // first make build
-                const [buildJobName, gitCommitHash, buildPromise] = await buildService.buildApp(deploymentId, app, forceBuild);
+                const [buildJobName, gitCommitHash, gitCommitMessage, buildPromise] = await buildService.buildApp(deploymentId, app, forceBuild);
                 buildPromise.then(async () => {
                     console.log('Build job finished, deploying...');
                     dlog(deploymentId, `Starting deployment with output from build "${buildJobName}"`);
-                    await deploymentService.createDeployment(deploymentId, app, buildJobName, gitCommitHash);
+                    await deploymentService.createDeployment(deploymentId, app, buildJobName, gitCommitHash, gitCommitMessage);
                 });
             } else {
                 // only deploy

--- a/src/server/services/build.service.ts
+++ b/src/server/services/build.service.ts
@@ -1,6 +1,6 @@
 import { AppExtendedModel } from "@/shared/model/app-extended.model";
 import k3s from "../adapter/kubernetes-api.adapter";
-import { V1Job, V1JobStatus } from "@kubernetes/client-node";
+import { V1Job, V1JobStatus, V1ResourceRequirements } from "@kubernetes/client-node";
 import { KubeObjectNameUtils } from "../utils/kube-object-name.utils";
 import { BuildJobModel } from "@/shared/model/build-job";
 import { ServiceException } from "@/shared/model/service.exception.model";
@@ -14,6 +14,7 @@ import stream from "stream";
 import { PathUtils } from "../utils/path.utils";
 import registryService, { BUILD_NAMESPACE } from "./registry.service";
 import paramService, { ParamService } from "./param.service";
+import clusterService from "./cluster.service";
 
 const buildkitImage = "moby/buildkit:master";
 
@@ -85,6 +86,77 @@ class BuildService {
 
         dlog(deploymentId, `Dockerfile context path: ${contextPaths.folderPath ?? 'root directory of Git Repository'}. Dockerfile name: ${contextPaths.filePath}`);
 
+        // Read global build settings
+        const buildNode = await paramService.getString(ParamService.BUILD_NODE);
+
+        // Determine node selector and resource limits based on build node setting
+        let nodeSelector: Record<string, string> | undefined;
+        let resources: V1ResourceRequirements | undefined;
+
+        if (buildNode === Constants.BUILD_NODE_K3S_NATIVE_VALUE) {
+            // k3s native: let k3s schedule based on resource limits, no nodeSelector
+            const [memoryLimit, memoryReservation, cpuLimit, cpuReservation] = await Promise.all([
+                paramService.getNumber(ParamService.BUILD_MEMORY_LIMIT),
+                paramService.getNumber(ParamService.BUILD_MEMORY_RESERVATION),
+                paramService.getNumber(ParamService.BUILD_CPU_LIMIT),
+                paramService.getNumber(ParamService.BUILD_CPU_RESERVATION),
+            ]);
+            const hasLimits = memoryLimit || cpuLimit;
+            const hasRequests = memoryReservation || cpuReservation;
+            if (hasLimits || hasRequests) {
+                resources = {
+                    ...(hasLimits ? {
+                        limits: {
+                            ...(cpuLimit ? { cpu: `${cpuLimit}m` } : {}),
+                            ...(memoryLimit ? { memory: `${memoryLimit}M` } : {}),
+                        }
+                    } : {}),
+                    ...(hasRequests ? {
+                        requests: {
+                            ...(cpuReservation ? { cpu: `${cpuReservation}m` } : {}),
+                            ...(memoryReservation ? { memory: `${memoryReservation}M` } : {}),
+                        }
+                    } : {}),
+                };
+            }
+            const resourceLimitsString = [
+                memoryLimit ? `memory limit: ${memoryLimit}M` : null,
+                memoryReservation ? `memory reservation: ${memoryReservation}M` : null,
+                cpuLimit ? `CPU limit: ${cpuLimit}m` : null,
+                cpuReservation ? `CPU reservation: ${cpuReservation}m` : null,
+            ]
+            dlog(deploymentId, `Build scheduling: k3s native - ${resourceLimitsString.filter(s => !!s).join(', ') || 'no resource limits or reservations configured'}`);
+        } else if (buildNode) {
+            // specific node pinned
+            const nodes = await clusterService.getNodeInfo();
+            const targetNode = nodes.find(n => n.name === buildNode);
+            if (!targetNode || !targetNode.schedulable) {
+                throw new ServiceException(
+                    `Configured build node '${buildNode}' is not schedulable. Please update build settings.`
+                );
+            }
+            nodeSelector = { 'kubernetes.io/hostname': buildNode };
+            dlog(deploymentId, `Build node pinned to: ${buildNode}`);
+        } else {
+            // auto: pick node with most available RAM
+            try {
+                const [nodeResources, nodeInfos] = await Promise.all([
+                    clusterService.getNodeResourceUsage(),
+                    clusterService.getNodeInfo(),
+                ]);
+                const schedulableNames = new Set(nodeInfos.filter(n => n.schedulable).map(n => n.name));
+                const bestNode = nodeResources
+                    .filter(n => schedulableNames.has(n.name))
+                    .sort((a, b) => (b.ramCapacity - b.ramUsage) - (a.ramCapacity - a.ramUsage))[0];
+                if (bestNode) {
+                    nodeSelector = { 'kubernetes.io/hostname': bestNode.name };
+                    dlog(deploymentId, `Auto-selected build node with most available resources: ${bestNode.name}`);
+                }
+            } catch {
+                dlog(deploymentId, `Could not determine best build node, scheduling on any available node.`);
+            }
+        }
+
         const jobDefinition: V1Job = {
             apiVersion: "batch/v1",
             kind: "Job",
@@ -104,6 +176,7 @@ class BuildService {
                     spec: {
                         // Depends on feature gate UserNamespacesSupport (available in k8s 1.25+)
                         hostUsers: false,
+                        ...(nodeSelector ? { nodeSelector } : {}),
                         containers: [
                             {
                                 name: buildName,
@@ -112,7 +185,8 @@ class BuildService {
                                 args: buildkitArgs,
                                 securityContext: {
                                     privileged: true
-                                }
+                                },
+                                ...(resources ? { resources } : {}),
                             },
                         ],
                         restartPolicy: "Never",

--- a/src/server/services/build.service.ts
+++ b/src/server/services/build.service.ts
@@ -203,7 +203,7 @@ class BuildService {
         await new Promise(resolve => setTimeout(resolve, 5000)); // wait to be sure that pod is created
         await this.logBuildOutput(deploymentId, buildName);
 
-        const buildJobPromise = this.waitForJobCompletion(jobDefinition.metadata!.name!)
+        const buildJobPromise = this.waitForJobCompletion(jobDefinition.metadata!.name!, deploymentId)
 
         return [buildName, latestRemoteGitHash, buildJobPromise];
     }
@@ -325,7 +325,7 @@ class BuildService {
         } as PodsInfoModel;
     }
 
-    async waitForJobCompletion(jobName: string) {
+    async waitForJobCompletion(jobName: string, deploymentId: string){
         const POLL_INTERVAL = 10000; // 10 seconds
         return await new Promise<void>((resolve, reject) => {
             const intervalId = setInterval(async () => {
@@ -334,16 +334,26 @@ class BuildService {
                     if (jobStatus === 'UNKNOWN') {
                         console.log(`Job ${jobName} not found.`);
                         clearInterval(intervalId);
+                        dlog(deploymentId, `***********************************`);
+                        dlog(deploymentId, ` ⚠ Build job ${jobName} not found.`);
+                        dlog(deploymentId, ` It might have been deleted manually or due to a cleanup process.`);
+                        dlog(deploymentId, `***********************************`);
                         reject(new Error(`Job ${jobName} not found.`));
                         return;
                     }
                     if (jobStatus === 'SUCCEEDED') {
                         clearInterval(intervalId);
                         console.log(`Job ${jobName} completed successfully.`);
+                        dlog(deploymentId, `*************************************`);
+                        dlog(deploymentId, ` ✓ Build job completed successfully. `);
+                        dlog(deploymentId, `*************************************`);
                         resolve();
                     } else if (jobStatus === 'FAILED') {
                         clearInterval(intervalId);
                         console.log(`Job ${jobName} failed.`);
+                        dlog(deploymentId, `*********************`);
+                        dlog(deploymentId, ` ⚠ Build job failed. `);
+                        dlog(deploymentId, `*********************`);
                         reject(new Error(`Job ${jobName} failed.`));
                     } else {
                         console.log(`Job ${jobName} is still running...`);

--- a/src/server/services/build.service.ts
+++ b/src/server/services/build.service.ts
@@ -21,7 +21,7 @@ const buildkitImage = "moby/buildkit:master";
 class BuildService {
 
 
-    async buildApp(deploymentId: string, app: AppExtendedModel, forceBuild: boolean = false): Promise<[string, string, Promise<void>]> {
+    async buildApp(deploymentId: string, app: AppExtendedModel, forceBuild: boolean = false): Promise<[string, string, string, Promise<void>]> {
         await namespaceService.createNamespaceIfNotExists(BUILD_NAMESPACE);
         const registryLocation = await paramService.getString(ParamService.REGISTRY_SOTRAGE_LOCATION, Constants.INTERNAL_REGISTRY_LOCATION);
         await registryService.deployRegistry(registryLocation!);
@@ -35,9 +35,13 @@ class BuildService {
 
         // Check if last build is already up to date with data in git repo
         const latestSuccessfulBuld = buildsForApp.find(x => x.status === 'SUCCEEDED');
-        const latestRemoteGitHash = await gitService.openGitContext(app, async (ctx) => {
+        const { latestRemoteGitHash, latestRemoteGitCommitMessage } = await gitService.openGitContext(app, async (ctx) => {
             await ctx.checkIfDockerfileExists();
-            return await ctx.getLatestRemoteCommitHash();
+            const [hash, message] = await Promise.all([
+                ctx.getLatestRemoteCommitHash(),
+                ctx.getLatestRemoteCommitMessage(),
+            ]);
+            return { latestRemoteGitHash: hash, latestRemoteGitCommitMessage: message };
         });
 
         dlog(deploymentId, `Cloned repository successfully`);
@@ -48,15 +52,15 @@ class BuildService {
 
             if (await registryService.doesImageExist(app.id, 'latest')) {
                 await dlog(deploymentId, `Latest build is already up to date with git repository, using container from last build.`);
-                return [latestSuccessfulBuld.name, latestRemoteGitHash, Promise.resolve()];
+                return [latestSuccessfulBuld.name, latestRemoteGitHash, latestRemoteGitCommitMessage, Promise.resolve()];
             } else {
                 await dlog(deploymentId, `Docker Image for last build not found in internal registry, creating new build.`);
             }
         }
-        return await this.createAndStartBuildJob(deploymentId, app, latestRemoteGitHash);
+        return await this.createAndStartBuildJob(deploymentId, app, latestRemoteGitHash, latestRemoteGitCommitMessage);
     }
 
-    private async createAndStartBuildJob(deploymentId: string, app: AppExtendedModel, latestRemoteGitHash: string): Promise<[string, string, Promise<void>]> {
+    private async createAndStartBuildJob(deploymentId: string, app: AppExtendedModel, latestRemoteGitHash: string, latestRemoteGitCommitMessage: string = ''): Promise<[string, string, string, Promise<void>]> {
 
         const buildName = KubeObjectNameUtils.addRandomSuffix(KubeObjectNameUtils.toJobName(app.id));
 
@@ -167,6 +171,7 @@ class BuildService {
                     [Constants.QS_ANNOTATION_APP_ID]: app.id,
                     [Constants.QS_ANNOTATION_PROJECT_ID]: app.projectId,
                     [Constants.QS_ANNOTATION_GIT_COMMIT]: latestRemoteGitHash,
+                    [Constants.QS_ANNOTATION_GIT_COMMIT_MESSAGE]: latestRemoteGitCommitMessage.substring(0, 200), // truncate to avoid exceeding 256 KiB size limits of annotations object.
                     [Constants.QS_ANNOTATION_DEPLOYMENT_ID]: deploymentId,
                 }
             },
@@ -205,7 +210,7 @@ class BuildService {
 
         const buildJobPromise = this.waitForJobCompletion(jobDefinition.metadata!.name!, deploymentId)
 
-        return [buildName, latestRemoteGitHash, buildJobPromise];
+        return [buildName, latestRemoteGitHash, latestRemoteGitCommitMessage, buildJobPromise];
     }
 
     async logBuildOutput(deploymentId: string, buildName: string) {
@@ -299,6 +304,7 @@ class BuildService {
                 startTime: job.status?.startTime,
                 status: this.getJobStatusString(job.status),
                 gitCommit: job.metadata?.annotations?.[Constants.QS_ANNOTATION_GIT_COMMIT],
+                gitCommitMessage: job.metadata?.annotations?.[Constants.QS_ANNOTATION_GIT_COMMIT_MESSAGE],
                 deploymentId: job.metadata?.annotations?.[Constants.QS_ANNOTATION_DEPLOYMENT_ID],
             } as BuildJobModel;
         });

--- a/src/server/services/deployment.service.ts
+++ b/src/server/services/deployment.service.ts
@@ -70,7 +70,7 @@ class DeploymentService {
         }
     }
 
-    async createDeployment(deploymentId: string, app: AppExtendedModel, buildJobName?: string, gitCommitHash?: string) {
+    async createDeployment(deploymentId: string, app: AppExtendedModel, buildJobName?: string, gitCommitHash?: string, gitCommitMessage?: string) {
         await this.validateDeployment(app);
 
         dlog(deploymentId, `Shutting down FileBrowsers (if active)`);
@@ -154,7 +154,11 @@ class DeploymentService {
         }
 
         if (gitCommitHash) {
-            body.spec!.template!.metadata!.annotations![Constants.QS_ANNOTATION_GIT_COMMIT] = gitCommitHash; // add gitCommitHash to deployment
+            body.spec!.template!.metadata!.annotations![Constants.QS_ANNOTATION_GIT_COMMIT] = gitCommitHash;
+        }
+
+        if (gitCommitMessage) {
+            body.spec!.template!.metadata!.annotations![Constants.QS_ANNOTATION_GIT_COMMIT_MESSAGE] = gitCommitMessage;
         }
 
         if (!appHasPvcChanges && app.appVolumes.length === 0 || app.appVolumes.every(vol => vol.accessMode === 'ReadWriteMany')) {
@@ -324,6 +328,7 @@ class DeploymentService {
                     buildJobName: build.name!,
                     status: this.mapBuildStatusToDeploymentStatus(build.status),
                     gitCommit: build.gitCommit,
+                    gitCommitMessage: build.gitCommitMessage,
                     deploymentId: build.deploymentId
                 }
             });
@@ -358,6 +363,7 @@ class DeploymentService {
                 createdAt: rs.metadata?.creationTimestamp!,
                 buildJobName: rs.spec?.template?.metadata?.annotations?.buildJobName!,
                 gitCommit: rs.spec?.template?.metadata?.annotations?.[Constants.QS_ANNOTATION_GIT_COMMIT],
+                gitCommitMessage: rs.spec?.template?.metadata?.annotations?.[Constants.QS_ANNOTATION_GIT_COMMIT_MESSAGE],
                 status: status,
                 deploymentId: rs.spec?.template?.metadata?.annotations?.[Constants.QS_ANNOTATION_DEPLOYMENT_ID]!
             }

--- a/src/server/services/git.service.ts
+++ b/src/server/services/git.service.ts
@@ -110,6 +110,11 @@ class InternalGitService {
             throw new ServiceException("The git repository is empty.");
         }
     }
+
+    async getLatestRemoteCommitMessage() {
+        const log = await this.git.log();
+        return log.latest?.message ?? '';
+    }
 }
 
 const gitService = new GitService();

--- a/src/server/services/param.service.ts
+++ b/src/server/services/param.service.ts
@@ -14,6 +14,11 @@ export class ParamService {
     static readonly PUBLIC_IPV4_ADDRESS = 'publicIpv4Address';
     static readonly QS_SYSTEM_BACKUP_LOCATION = Constants.QS_SYSTEM_BACKUP_LOCATION_PARAM_KEY;
     static readonly K3S_JOIN_TOKEN = Constants.K3S_JOIN_TOKEN;
+    static readonly BUILD_MEMORY_LIMIT = 'buildMemoryLimit';
+    static readonly BUILD_MEMORY_RESERVATION = 'buildMemoryReservation';
+    static readonly BUILD_CPU_LIMIT = 'buildCpuLimit';
+    static readonly BUILD_CPU_RESERVATION = 'buildCpuReservation';
+    static readonly BUILD_NODE = 'buildNode';
 
     async getUncached(name: string) {
         return await dataAccess.client.parameter.findFirstOrThrow({
@@ -94,6 +99,22 @@ export class ParamService {
 
     async deleteByName(name: string) {
         const existingParam = await this.get(name);
+        if (!existingParam) {
+            return;
+        }
+        try {
+            await dataAccess.client.parameter.delete({
+                where: {
+                    name
+                }
+            });
+        } finally {
+            revalidateTag(Tags.parameter());
+        }
+    }
+
+    async deleteByNameIfExists(name: string) {
+        const existingParam = await this.getOrUndefined(name);
         if (!existingParam) {
             return;
         }

--- a/src/shared/model/build-job.ts
+++ b/src/shared/model/build-job.ts
@@ -8,6 +8,7 @@ export const buildJobSchemaZod = z.object({
     startTime: z.date(),
     status:  buildJobStatusEnumZod,
     gitCommit: z.string(),
+    gitCommitMessage: z.string().optional(),
     deploymentId: z.string(),
 });
 

--- a/src/shared/model/build-settings.model.ts
+++ b/src/shared/model/build-settings.model.ts
@@ -1,0 +1,12 @@
+import { stringToOptionalNumber } from "@/shared/utils/zod.utils";
+import { z } from "zod";
+
+export const buildSettingsZodModel = z.object({
+    memoryReservation: stringToOptionalNumber,
+    memoryLimit: stringToOptionalNumber,
+    cpuReservation: stringToOptionalNumber,
+    cpuLimit: stringToOptionalNumber,
+    buildNode: z.string().optional().nullable(),
+});
+
+export type BuildSettingsModel = z.infer<typeof buildSettingsZodModel>;

--- a/src/shared/model/deployment-info.model.ts
+++ b/src/shared/model/deployment-info.model.ts
@@ -16,6 +16,7 @@ export const deploymentInfoZodModel = z.object({
     createdAt: z.date(),
     status: deploymentStatusEnumZod,
     gitCommit: z.string().optional(),
+    gitCommitMessage: z.string().optional(),
     deploymentId: z.string(),
 });
 

--- a/src/shared/utils/constants.ts
+++ b/src/shared/utils/constants.ts
@@ -21,4 +21,6 @@ export class Constants {
     static readonly DEFAULT_HEALTH_CHECK_TIMEOUT_SECONDS = 10;
     static readonly DEFAULT_HEALTH_CHECK_FAILURE_THRESHOLD = 3;
     static readonly TOLERATION_FOR_EXECUTED_CRON_BACKUPS_MS = 60 * 60 * 1000; // 60 minutes;
+    static readonly BUILD_NODE_K3S_NATIVE_VALUE = 'k3s-native';
+    static readonly BUILD_AUTO_NODE_VALUE = '__auto__';
 }

--- a/src/shared/utils/constants.ts
+++ b/src/shared/utils/constants.ts
@@ -6,6 +6,7 @@ export class Constants {
     static readonly QS_ANNOTATION_CONTAINER_TYPE_DB_TOOL = 'qs-container-db-tool';
     static readonly QS_ANNOTATION_DEPLOYMENT_ID = 'qs-deplyoment-id';
     static readonly QS_ANNOTATION_GIT_COMMIT = 'qs-git-commit';
+    static readonly QS_ANNOTATION_GIT_COMMIT_MESSAGE = 'qs-git-commit-message';
     static readonly K3S_JOIN_TOKEN = 'k3sJoinToken';
     static readonly QS_NAMESPACE = 'quickstack';
     static readonly QS_APP_NAME = 'quickstack';


### PR DESCRIPTION
This pull request introduces a new "Builds" settings tab in the server settings UI, allowing administrators to configure global build container resource limits and node placement. It also extends the backend to support saving and retrieving these build settings, and enhances the build and deployment flow to track and display the Git commit message associated with each build.

Relates to issues described in: https://github.com/biersoeckli/QuickStack/issues/80