### PR TITLE
fix: ensure resource requests are preserved when setting CPU and memory reservations

### DIFF
--- a/src/server/services/deployment.service.ts
+++ b/src/server/services/deployment.service.ts
@@ -207,6 +207,7 @@ class DeploymentService {
 
         if (app.cpuReservation || app.memoryReservation) {
             body.spec!.template!.spec!.containers[0].resources = {
+                ...body.spec!.template!.spec!.containers[0].resources,
                 requests: {}
             }
             if (app.cpuReservation) {


### PR DESCRIPTION
Fix: Preserve container resource limits when CPU or memory reservations are configured.

`requests` are now merged into the existing Kubernetes `resources` object instead of replacing it, so deployments include both `limits` and `requests`.

Thanks @Wissiak