### PR TITLE
fix: advanced S3 registry options + upgrade registry to v3

### DIFF
--- a/additional-containers/mariadb-backup/backup.sh
+++ b/additional-containers/mariadb-backup/backup.sh
@@ -61,6 +61,25 @@ export AWS_ACCESS_KEY_ID="$S3_ACCESS_KEY_ID"
 export AWS_SECRET_ACCESS_KEY="$S3_SECRET_KEY"
 export AWS_DEFAULT_REGION="$S3_REGION"
 
+# Apply advanced S3 options (addressing style + signature version) when provided by QuickStack
+if [ -n "$S3_FORCE_PATH_STYLE" ] || [ -n "$S3_V4AUTH" ]; then
+    AWS_CONFIG_FILE="${AWS_CONFIG_FILE:-$HOME/.aws/config}"
+    mkdir -p "$(dirname "$AWS_CONFIG_FILE")"
+
+    ADDRESSING_STYLE="virtual"
+    if [ "$S3_FORCE_PATH_STYLE" = "true" ]; then
+        ADDRESSING_STYLE="path"
+    fi
+    SIGNATURE_VERSION="s3v4"
+    if [ "$S3_V4AUTH" = "false" ]; then
+        SIGNATURE_VERSION="s3"
+    fi
+
+    printf '[default]\ns3 =\n  addressing_style = %s\n  signature_version = %s\n' "$ADDRESSING_STYLE" "$SIGNATURE_VERSION" > "$AWS_CONFIG_FILE"
+    export AWS_CONFIG_FILE
+    echo "S3 addressing style: $ADDRESSING_STYLE (signature $SIGNATURE_VERSION)"
+fi
+
 # Upload to S3
 echo "Uploading to S3..."
 echo "Destination: s3://$S3_BUCKET_NAME/$S3_KEY"

--- a/additional-containers/mariadb-backup/docker-compose.yml
+++ b/additional-containers/mariadb-backup/docker-compose.yml
@@ -40,4 +40,6 @@ services:
       S3_REGION: "us-east-1"
       S3_ACCESS_KEY_ID: " "
       S3_SECRET_KEY: " "
+      S3_FORCE_PATH_STYLE: "false" # set to "true" for path-style providers (e.g. MinIO)
+      S3_V4AUTH: "true"
       S3_KEY: "backup-2025-01-01.zip"

--- a/additional-containers/mongodb-backup/backup.sh
+++ b/additional-containers/mongodb-backup/backup.sh
@@ -51,6 +51,25 @@ export AWS_ACCESS_KEY_ID="$S3_ACCESS_KEY_ID"
 export AWS_SECRET_ACCESS_KEY="$S3_SECRET_KEY"
 export AWS_DEFAULT_REGION="$S3_REGION"
 
+# Apply advanced S3 options (addressing style + signature version) when provided by QuickStack
+if [ -n "$S3_FORCE_PATH_STYLE" ] || [ -n "$S3_V4AUTH" ]; then
+    AWS_CONFIG_FILE="${AWS_CONFIG_FILE:-$HOME/.aws/config}"
+    mkdir -p "$(dirname "$AWS_CONFIG_FILE")"
+
+    ADDRESSING_STYLE="virtual"
+    if [ "$S3_FORCE_PATH_STYLE" = "true" ]; then
+        ADDRESSING_STYLE="path"
+    fi
+    SIGNATURE_VERSION="s3v4"
+    if [ "$S3_V4AUTH" = "false" ]; then
+        SIGNATURE_VERSION="s3"
+    fi
+
+    printf '[default]\ns3 =\n  addressing_style = %s\n  signature_version = %s\n' "$ADDRESSING_STYLE" "$SIGNATURE_VERSION" > "$AWS_CONFIG_FILE"
+    export AWS_CONFIG_FILE
+    echo "S3 addressing style: $ADDRESSING_STYLE (signature $SIGNATURE_VERSION)"
+fi
+
 # Upload to S3
 echo "Uploading to S3..."
 echo "Destination: s3://$S3_BUCKET_NAME/$S3_KEY"

--- a/additional-containers/mongodb-backup/docker-compose.yml
+++ b/additional-containers/mongodb-backup/docker-compose.yml
@@ -34,4 +34,6 @@ services:
       S3_REGION: "us-east-1"
       S3_ACCESS_KEY_ID: " "
       S3_SECRET_KEY: " "
+      S3_FORCE_PATH_STYLE: "false" # set to "true" for path-style providers (e.g. MinIO)
+      S3_V4AUTH: "true"
       S3_KEY: "backup-2025-01-01.zip"

--- a/additional-containers/postgres-backup/backup.sh
+++ b/additional-containers/postgres-backup/backup.sh
@@ -63,6 +63,25 @@ export AWS_ACCESS_KEY_ID="$S3_ACCESS_KEY_ID"
 export AWS_SECRET_ACCESS_KEY="$S3_SECRET_KEY"
 export AWS_DEFAULT_REGION="$S3_REGION"
 
+# Apply advanced S3 options (addressing style + signature version) when provided by QuickStack
+if [ -n "$S3_FORCE_PATH_STYLE" ] || [ -n "$S3_V4AUTH" ]; then
+    AWS_CONFIG_FILE="${AWS_CONFIG_FILE:-$HOME/.aws/config}"
+    mkdir -p "$(dirname "$AWS_CONFIG_FILE")"
+
+    ADDRESSING_STYLE="virtual"
+    if [ "$S3_FORCE_PATH_STYLE" = "true" ]; then
+        ADDRESSING_STYLE="path"
+    fi
+    SIGNATURE_VERSION="s3v4"
+    if [ "$S3_V4AUTH" = "false" ]; then
+        SIGNATURE_VERSION="s3"
+    fi
+
+    printf '[default]\ns3 =\n  addressing_style = %s\n  signature_version = %s\n' "$ADDRESSING_STYLE" "$SIGNATURE_VERSION" > "$AWS_CONFIG_FILE"
+    export AWS_CONFIG_FILE
+    echo "S3 addressing style: $ADDRESSING_STYLE (signature $SIGNATURE_VERSION)"
+fi
+
 # Upload to S3
 echo "Uploading to S3..."
 echo "Destination: s3://$S3_BUCKET_NAME/$S3_KEY"

--- a/additional-containers/postgres-backup/docker-compose.yml
+++ b/additional-containers/postgres-backup/docker-compose.yml
@@ -39,4 +39,6 @@ services:
       S3_REGION: " "
       S3_ACCESS_KEY_ID: " "
       S3_SECRET_KEY: " "
+      S3_FORCE_PATH_STYLE: "false" # set to "true" for path-style providers (e.g. MinIO)
+      S3_V4AUTH: "true"
       S3_KEY: "backup-2025-01-01.zip"

--- a/prisma/migrations/20260905081858_add_s3_registry_options/migration.sql
+++ b/prisma/migrations/20260905081858_add_s3_registry_options/migration.sql
@@ -1,0 +1,22 @@
+-- RedefineTables
+PRAGMA defer_foreign_keys=ON;
+PRAGMA foreign_keys=OFF;
+CREATE TABLE "new_S3Target" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "name" TEXT NOT NULL,
+    "bucketName" TEXT NOT NULL,
+    "endpoint" TEXT NOT NULL,
+    "region" TEXT NOT NULL,
+    "accessKeyId" TEXT NOT NULL,
+    "secretKey" TEXT NOT NULL,
+    "useSsl" BOOLEAN NOT NULL DEFAULT true,
+    "v4Auth" BOOLEAN NOT NULL DEFAULT true,
+    "forcePathStyle" BOOLEAN NOT NULL DEFAULT false,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL
+);
+INSERT INTO "new_S3Target" ("accessKeyId", "bucketName", "createdAt", "endpoint", "id", "name", "region", "secretKey", "updatedAt") SELECT "accessKeyId", "bucketName", "createdAt", "endpoint", "id", "name", "region", "secretKey", "updatedAt" FROM "S3Target";
+DROP TABLE "S3Target";
+ALTER TABLE "new_S3Target" RENAME TO "S3Target";
+PRAGMA foreign_keys=ON;
+PRAGMA defer_foreign_keys=OFF;

--- a/prisma/migrations/20260906084635_migration/migration.sql
+++ b/prisma/migrations/20260906084635_migration/migration.sql
@@ -1,0 +1,24 @@
+-- RedefineTables
+PRAGMA defer_foreign_keys=ON;
+PRAGMA foreign_keys=OFF;
+CREATE TABLE "new_User" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "name" TEXT,
+    "email" TEXT NOT NULL,
+    "emailVerified" DATETIME,
+    "password" TEXT NOT NULL DEFAULT '',
+    "twoFaSecret" TEXT,
+    "twoFaEnabled" BOOLEAN NOT NULL DEFAULT false,
+    "apiOnlyUser" BOOLEAN NOT NULL DEFAULT false,
+    "image" TEXT,
+    "userGroupId" TEXT,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL,
+    CONSTRAINT "User_userGroupId_fkey" FOREIGN KEY ("userGroupId") REFERENCES "UserGroup" ("id") ON DELETE SET NULL ON UPDATE CASCADE
+);
+INSERT INTO "new_User" ("apiOnlyUser", "createdAt", "email", "emailVerified", "id", "image", "name", "password", "twoFaEnabled", "twoFaSecret", "updatedAt", "userGroupId") SELECT "apiOnlyUser", "createdAt", "email", "emailVerified", "id", "image", "name", "password", "twoFaEnabled", "twoFaSecret", "updatedAt", "userGroupId" FROM "User";
+DROP TABLE "User";
+ALTER TABLE "new_User" RENAME TO "User";
+CREATE UNIQUE INDEX "User_email_key" ON "User"("email");
+PRAGMA foreign_keys=ON;
+PRAGMA defer_foreign_keys=OFF;

--- a/prisma/migrations/20260906094500_remove_s3_target_use_ssl/migration.sql
+++ b/prisma/migrations/20260906094500_remove_s3_target_use_ssl/migration.sql
@@ -1,0 +1,27 @@
+-- S3Target.endpoint is the sole source of truth for HTTP versus HTTPS.
+PRAGMA defer_foreign_keys=ON;
+PRAGMA foreign_keys=OFF;
+
+CREATE TABLE "new_S3Target" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "name" TEXT NOT NULL,
+    "bucketName" TEXT NOT NULL,
+    "endpoint" TEXT NOT NULL,
+    "region" TEXT NOT NULL,
+    "accessKeyId" TEXT NOT NULL,
+    "secretKey" TEXT NOT NULL,
+    "v4Auth" BOOLEAN NOT NULL DEFAULT true,
+    "forcePathStyle" BOOLEAN NOT NULL DEFAULT false,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL
+);
+
+INSERT INTO "new_S3Target" ("id", "name", "bucketName", "endpoint", "region", "accessKeyId", "secretKey", "v4Auth", "forcePathStyle", "createdAt", "updatedAt")
+SELECT "id", "name", "bucketName", "endpoint", "region", "accessKeyId", "secretKey", "v4Auth", "forcePathStyle", "createdAt", "updatedAt"
+FROM "S3Target";
+
+DROP TABLE "S3Target";
+ALTER TABLE "new_S3Target" RENAME TO "S3Target";
+
+PRAGMA foreign_keys=ON;
+PRAGMA defer_foreign_keys=OFF;

--- a/prisma/migrations/20260906095500_normalize_s3_target_endpoint_scheme/migration.sql
+++ b/prisma/migrations/20260906095500_normalize_s3_target_endpoint_scheme/migration.sql
@@ -1,0 +1,6 @@
+-- S3Target.endpoint stores the complete endpoint URL. Preserve explicit
+-- schemes and make legacy host-only endpoints use HTTPS.
+UPDATE "S3Target"
+SET "endpoint" = 'https://' || "endpoint"
+WHERE lower("endpoint") NOT LIKE 'http://%'
+  AND lower("endpoint") NOT LIKE 'https://%';

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -579,7 +579,6 @@ model S3Target {
   region        String
   accessKeyId    String
   secretKey      String
-  useSsl         Boolean  @default(true) // use HTTPS (registry storage `secure`, S3 client scheme)
   v4Auth         Boolean  @default(true) // use AWS Signature Version 4 (registry storage `v4auth`)
   forcePathStyle Boolean  @default(false) // use path-style S3 addressing (registry storage `forcepathstyle`)
   volumeBackups  VolumeBackup[]

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -577,9 +577,12 @@ model S3Target {
   bucketName    String
   endpoint      String
   region        String
-  accessKeyId   String
-  secretKey     String
-  volumeBackups VolumeBackup[]
+  accessKeyId    String
+  secretKey      String
+  useSsl         Boolean  @default(true) // use HTTPS (registry storage `secure`, S3 client scheme)
+  v4Auth         Boolean  @default(true) // use AWS Signature Version 4 (registry storage `v4auth`)
+  forcePathStyle Boolean  @default(false) // use path-style S3 addressing (registry storage `forcepathstyle`)
+  volumeBackups  VolumeBackup[]
 
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt

--- a/src/app/api/init/route.ts
+++ b/src/app/api/init/route.ts
@@ -3,6 +3,7 @@ import buildPodLogWatchService from "@/server/services/standalone-services/build
 import buildWatchService from "@/server/services/standalone-services/build-watch.service";
 import deploymentEventWatchService from "@/server/services/standalone-services/deployment-event-watch.service";
 import registryService from "@/server/services/registry.service";
+import s3TargetService from "@/server/services/s3-target.service";
 import { Constants } from "@/shared/utils/constants";
 import { simpleRoute } from "@/server/utils/action-wrapper.utils";
 import { NextResponse } from "next/server";
@@ -27,7 +28,12 @@ export async function GET(request: Request) {
 
         // Always (re)deploy the registry on startup so storage settings and image version are never stale.
         const registryLocation = await paramService.getString(ParamService.REGISTRY_SOTRAGE_LOCATION, Constants.INTERNAL_REGISTRY_LOCATION);
-        await registryService.deployRegistry(registryLocation!, true);
+        const isLocalRegistryStorage = registryLocation === Constants.INTERNAL_REGISTRY_LOCATION;
+        if (isLocalRegistryStorage || await s3TargetService.existsById(registryLocation!)) {
+            await registryService.deployRegistry(registryLocation!, true);
+        } else {
+            console.warn(`Skipping registry deployment because S3 target ${registryLocation} no longer exists.`);
+        }
 
         console.log('Initialized services successfully via init route for instanceId:', instanceId);
         return NextResponse.json({ status: "ok" });

--- a/src/app/api/init/route.ts
+++ b/src/app/api/init/route.ts
@@ -2,6 +2,8 @@ import paramService, { ParamService } from "@/server/services/param.service";
 import buildPodLogWatchService from "@/server/services/standalone-services/build-pod-log-watch.service";
 import buildWatchService from "@/server/services/standalone-services/build-watch.service";
 import deploymentEventWatchService from "@/server/services/standalone-services/deployment-event-watch.service";
+import registryService from "@/server/services/registry.service";
+import { Constants } from "@/shared/utils/constants";
 import { simpleRoute } from "@/server/utils/action-wrapper.utils";
 import { NextResponse } from "next/server";
 
@@ -20,7 +22,12 @@ export async function GET(request: Request) {
         await buildWatchService.startWatch();
         await buildPodLogWatchService.startWatch();
         await deploymentEventWatchService.startWatch();
+
         const instanceId = await paramService.getOrCreate(ParamService.QS_INSTANCE_ID, crypto.randomUUID());
+
+        // Always (re)deploy the registry on startup so storage settings and image version are never stale.
+        const registryLocation = await paramService.getString(ParamService.REGISTRY_SOTRAGE_LOCATION, Constants.INTERNAL_REGISTRY_LOCATION);
+        await registryService.deployRegistry(registryLocation!, true);
 
         console.log('Initialized services successfully via init route for instanceId:', instanceId);
         return NextResponse.json({ status: "ok" });

--- a/src/app/backups/backup-detail-overlay.tsx
+++ b/src/app/backups/backup-detail-overlay.tsx
@@ -29,6 +29,11 @@ export function BackupDetailDialog({
     const { openConfirmDialog } = useConfirmDialog();
     const [isOpen, setIsOpen] = React.useState(false);
     const [isLoading, setIsLoading] = React.useState(false);
+    const [backups, setBackups] = React.useState(backupInfo.backups);
+
+    React.useEffect(() => {
+        setBackups(backupInfo.backups);
+    }, [backupInfo.backups]);
 
     const asyncDownloadPvcData = async (s3Key: string) => {
         try {
@@ -49,7 +54,15 @@ export function BackupDetailDialog({
             description: 'This action deletes the backup from the storage. This action cannot be undone.',
             okButton: 'Delete'
         })) {
-            await Toast.fromAction(() => deleteBackup(backupInfo.s3TargetId, s3Key));
+            try {
+                setIsLoading(true);
+                const result = await Toast.fromAction(() => deleteBackup(backupInfo.s3TargetId, s3Key));
+                if (result.status === 'success') {
+                    setBackups((currentBackups) => currentBackups.filter((backup) => backup.key !== s3Key));
+                }
+            } finally {
+                setIsLoading(false);
+            }
         }
     }
 
@@ -71,7 +84,7 @@ export function BackupDetailDialog({
                 </DialogHeader>
                 <ScrollArea className="max-h-[70vh]">
                     <Table>
-                        <TableCaption>{backupInfo.backups.length} Backups</TableCaption>
+                        <TableCaption>{backups.length} Backups</TableCaption>
                         <TableHeader>
                             <TableRow>
                                 <TableHead>Time</TableHead>
@@ -80,8 +93,8 @@ export function BackupDetailDialog({
                             </TableRow>
                         </TableHeader>
                         <TableBody>
-                            {backupInfo.backups.map((item, index) => (
-                                <TableRow key={index}>
+                            {backups.map((item) => (
+                                <TableRow key={item.key}>
                                     <TableCell>{formatDateTime(item.backupDate, true)}</TableCell>
                                     <TableCell>{item.sizeBytes ? KubeSizeConverter.convertBytesToReadableSize(item.sizeBytes) : 'unknown'}</TableCell>
                                     <TableCell className="flex justify-end gap-2">

--- a/src/app/settings/s3-targets/actions.ts
+++ b/src/app/settings/s3-targets/actions.ts
@@ -5,6 +5,7 @@ import { getAdminUserSession, saveFormAction, simpleAction } from "@/server/util
 import { S3TargetEditModel, s3TargetEditZodModel } from "@/shared/model/s3-target-edit.model";
 import s3TargetService from "@/server/services/s3-target.service";
 import s3Service from "@/server/services/aws-s3.service";
+import s3Adapter from "@/server/adapter/aws-s3.adapter";
 import { S3Target } from "@prisma/client";
 import { ServiceException } from "@/shared/model/service.exception.model";
 
@@ -12,7 +13,7 @@ export const saveS3Target = async (prevState: any, inputData: S3TargetEditModel)
     saveFormAction(inputData, s3TargetEditZodModel, async (validatedData) => {
         await getAdminUserSession();
 
-        const url = new URL(validatedData.endpoint.includes('://') ? validatedData.endpoint : `https://${validatedData.endpoint}`);
+        const url = new URL(s3Adapter.getEndpointUrl(validatedData.endpoint, validatedData.useSsl));
         validatedData.endpoint = url.origin;
 
         if (!await s3Service.testConnection(validatedData as S3Target)) {

--- a/src/app/settings/s3-targets/actions.ts
+++ b/src/app/settings/s3-targets/actions.ts
@@ -13,9 +13,8 @@ export const saveS3Target = async (prevState: any, inputData: S3TargetEditModel)
     saveFormAction(inputData, s3TargetEditZodModel, async (validatedData) => {
         await getAdminUserSession();
 
-        const url = new URL(s3Adapter.getEndpointUrl(validatedData.endpoint, validatedData.useSsl));
+        const url = new URL(s3Adapter.getEndpointUrl(validatedData.endpoint));
         validatedData.endpoint = url.origin;
-
         if (!await s3Service.testConnection(validatedData as S3Target)) {
             throw new ServiceException('Could not connect to S3 Target, please check your credentials and try again');
         }

--- a/src/app/settings/s3-targets/s3-target-edit-overlay.tsx
+++ b/src/app/settings/s3-targets/s3-target-edit-overlay.tsx
@@ -159,9 +159,7 @@ export default function S3TargetEditOverlay({ children, target }: { children: Re
                     />
 
                     <p className="text-sm font-medium pt-2">Advanced Options</p>
-                    <p className="text-sm text-muted-foreground -mt-2">
-                      Connection options for S3-compatible providers. Used for the internal registry storage.
-                    </p>
+                   
 
                     <CheckboxFormField form={form} name="useSsl" label="Use HTTPS / SSL (secure connection)" />
                     <CheckboxFormField form={form} name="v4Auth" label="Use AWS Signature Version 4 (v4auth)" />

--- a/src/app/settings/s3-targets/s3-target-edit-overlay.tsx
+++ b/src/app/settings/s3-targets/s3-target-edit-overlay.tsx
@@ -23,6 +23,7 @@ import { toast } from "sonner"
 import { S3TargetEditModel, s3TargetEditZodModel } from "@/shared/model/s3-target-edit.model"
 import { saveS3Target } from "./actions"
 import { ScrollArea } from "@/components/ui/scroll-area"
+import CheckboxFormField from "@/components/custom/checkbox-form-field"
 
 
 export default function S3TargetEditOverlay({ children, target }: { children: React.ReactNode; target?: S3Target; }) {
@@ -156,6 +157,15 @@ export default function S3TargetEditOverlay({ children, target }: { children: Re
                         </FormItem>
                       )}
                     />
+
+                    <p className="text-sm font-medium pt-2">Advanced Options</p>
+                    <p className="text-sm text-muted-foreground -mt-2">
+                      Connection options for S3-compatible providers. Used for the internal registry storage.
+                    </p>
+
+                    <CheckboxFormField form={form} name="useSsl" label="Use HTTPS / SSL (secure connection)" />
+                    <CheckboxFormField form={form} name="v4Auth" label="Use AWS Signature Version 4 (v4auth)" />
+                    <CheckboxFormField form={form} name="forcePathStyle" label="Force path-style addressing (forcepathstyle)" />
 
                     <p className="text-red-500">{state.message}</p>
                     <SubmitButton>Save</SubmitButton>

--- a/src/app/settings/s3-targets/s3-target-edit-overlay.tsx
+++ b/src/app/settings/s3-targets/s3-target-edit-overlay.tsx
@@ -25,6 +25,7 @@ import { saveS3Target } from "./actions"
 import { ScrollArea } from "@/components/ui/scroll-area"
 import CheckboxFormField from "@/components/custom/checkbox-form-field"
 
+const NEW_S3_TARGET_DEFAULT_VALUES = { useSsl: true }
 
 export default function S3TargetEditOverlay({ children, target }: { children: React.ReactNode; target?: S3Target; }) {
 
@@ -33,7 +34,7 @@ export default function S3TargetEditOverlay({ children, target }: { children: Re
 
   const form = useForm<z.input<typeof s3TargetEditZodModel>, unknown, z.output<typeof s3TargetEditZodModel>>({
     resolver: zodResolver(s3TargetEditZodModel),
-    defaultValues: target
+    defaultValues: target ?? NEW_S3_TARGET_DEFAULT_VALUES
   });
 
   const [state, formAction] = useActionState((state: ServerActionResult<any, any>,
@@ -53,7 +54,7 @@ export default function S3TargetEditOverlay({ children, target }: { children: Re
   }, [form, state]);
 
   useEffect(() => {
-    form.reset(target);
+    form.reset(target ?? NEW_S3_TARGET_DEFAULT_VALUES);
   }, [form, target]);
 
   return (

--- a/src/app/settings/s3-targets/s3-target-edit-overlay.tsx
+++ b/src/app/settings/s3-targets/s3-target-edit-overlay.tsx
@@ -25,7 +25,7 @@ import { saveS3Target } from "./actions"
 import { ScrollArea } from "@/components/ui/scroll-area"
 import CheckboxFormField from "@/components/custom/checkbox-form-field"
 
-const NEW_S3_TARGET_DEFAULT_VALUES = { useSsl: true }
+const NEW_S3_TARGET_DEFAULT_VALUES = { v4Auth: true }
 
 export default function S3TargetEditOverlay({ children, target }: { children: React.ReactNode; target?: S3Target; }) {
 
@@ -160,9 +160,7 @@ export default function S3TargetEditOverlay({ children, target }: { children: Re
                     />
 
                     <p className="text-sm font-medium pt-2">Advanced Options</p>
-                   
 
-                    <CheckboxFormField form={form} name="useSsl" label="Use HTTPS / SSL (secure connection)" />
                     <CheckboxFormField form={form} name="v4Auth" label="Use AWS Signature Version 4 (v4auth)" />
                     <CheckboxFormField form={form} name="forcePathStyle" label="Force path-style addressing (forcepathstyle)" />
 

--- a/src/app/settings/s3-targets/s3-targets-table.tsx
+++ b/src/app/settings/s3-targets/s3-targets-table.tsx
@@ -15,10 +15,10 @@ export default function S3TargetsTable({ targets }: {
     targets: S3Target[]
 }) {
 
-    const { openConfirmDialog: openDialog } = useConfirmDialog();
+    const { openConfirmDialog } = useConfirmDialog();
 
     const asyncDeleteTarget = async (id: string) => {
-        const confirm = await openDialog({
+        const confirm = await openConfirmDialog({
             title: "Delete S3 Target",
             description: "Do you really want to delete this S3 Target?",
             okButton: "Delete S3 Target"

--- a/src/app/settings/server/update-info.tsx
+++ b/src/app/settings/server/update-info.tsx
@@ -48,7 +48,9 @@ export default async function UpdateInfoPage() {
         console.error('Error fetching K3s version info:', error);
     }
 
-    const addons: ClusterAddonUpdateInfoModel[] = await Promise.all(clusterAddonRegistryService.getAll().map(async (addon) => {
+    const addons: ClusterAddonUpdateInfoModel[] = await Promise.all(clusterAddonRegistryService.getAll()
+        .filter((addon) => useCanaryChannel || addon.metadata.id !== 'agent-sandbox')
+        .map(async (addon) => {
         try {
             const status = await addon.getStatus();
             let availableVersion: string | undefined;
@@ -65,7 +67,7 @@ export default async function UpdateInfoPage() {
             const message = error instanceof Error ? error.message : 'Could not load add-on status.';
             return { ...addon.metadata, status: 'failed' as const, message };
         }
-    }));
+        }));
 
 
     return <div className="grid gap-6">

--- a/src/server/adapter/aws-s3.adapter.ts
+++ b/src/server/adapter/aws-s3.adapter.ts
@@ -2,15 +2,18 @@ import { S3Client } from "@aws-sdk/client-s3";
 
 import { S3Target } from "@prisma/client";
 
-export type S3ClientTarget = Pick<S3Target, 'region' | 'accessKeyId' | 'secretKey' | 'endpoint' | 'useSsl' | 'forcePathStyle'>;
+export type S3ClientTarget = Pick<S3Target, 'region' | 'accessKeyId' | 'secretKey' | 'endpoint' | 'forcePathStyle'>;
 
 class AwsS3Adapter {
 
-    getEndpointUrl(endpoint: string, useSsl: boolean) {
-        const host = /^https?:\/\//i.test(endpoint)
-            ? endpoint.replace(/^https?:\/\//i, '')
-            : endpoint;
-        return `${useSsl ? 'https' : 'http'}://${host}`;
+    getEndpointUrl(endpoint: string) {
+        return /^https?:\/\//i.test(endpoint)
+            ? endpoint
+            : `https://${endpoint}`;
+    }
+
+    isSecureEndpoint(endpoint: string) {
+        return new URL(this.getEndpointUrl(endpoint)).protocol === 'https:';
     }
 
     getS3Client(s3Target: S3ClientTarget) {
@@ -20,7 +23,7 @@ class AwsS3Adapter {
                 accessKeyId: s3Target.accessKeyId,
                 secretAccessKey: s3Target.secretKey,
             },
-            endpoint: this.getEndpointUrl(s3Target.endpoint, s3Target.useSsl),
+            endpoint: this.getEndpointUrl(s3Target.endpoint),
             forcePathStyle: s3Target.forcePathStyle,
         });
     }

--- a/src/server/adapter/aws-s3.adapter.ts
+++ b/src/server/adapter/aws-s3.adapter.ts
@@ -2,18 +2,26 @@ import { S3Client } from "@aws-sdk/client-s3";
 
 import { S3Target } from "@prisma/client";
 
+export type S3ClientTarget = Pick<S3Target, 'region' | 'accessKeyId' | 'secretKey' | 'endpoint' | 'useSsl' | 'forcePathStyle'>;
+
 class AwsS3Adapter {
 
-    getS3Client(s3Target: S3Target) {
+    getEndpointUrl(endpoint: string, useSsl: boolean) {
+        const host = /^https?:\/\//i.test(endpoint)
+            ? endpoint.replace(/^https?:\/\//i, '')
+            : endpoint;
+        return `${useSsl ? 'https' : 'http'}://${host}`;
+    }
+
+    getS3Client(s3Target: S3ClientTarget) {
         return new S3Client({
             region: s3Target.region,
             credentials: {
                 accessKeyId: s3Target.accessKeyId,
                 secretAccessKey: s3Target.secretKey,
             },
-            endpoint: /^https?:\/\//.test(s3Target.endpoint)
-                ? s3Target.endpoint
-                : `https://${s3Target.endpoint}`
+            endpoint: this.getEndpointUrl(s3Target.endpoint, s3Target.useSsl),
+            forcePathStyle: s3Target.forcePathStyle,
         });
     }
 }

--- a/src/server/adapter/aws-s3.adapter.unit.spec.ts
+++ b/src/server/adapter/aws-s3.adapter.unit.spec.ts
@@ -4,16 +4,21 @@ import s3Adapter from './aws-s3.adapter';
 describe('AwsS3Adapter', () => {
 
     describe('getEndpointUrl', () => {
-        it('adds https scheme when useSsl is true and endpoint has no scheme', () => {
-            expect(s3Adapter.getEndpointUrl('nbg1.your-objectstorage.com', true)).toBe('https://nbg1.your-objectstorage.com');
+        it('adds https scheme when endpoint has no scheme', () => {
+            expect(s3Adapter.getEndpointUrl('nbg1.your-objectstorage.com')).toBe('https://nbg1.your-objectstorage.com');
         });
 
-        it('keeps host and switches to http when useSsl is false', () => {
-            expect(s3Adapter.getEndpointUrl('https://nbg1.your-objectstorage.com', false)).toBe('http://nbg1.your-objectstorage.com');
+        it('preserves an explicit http scheme', () => {
+            expect(s3Adapter.getEndpointUrl('http://minio.local:9000')).toBe('http://minio.local:9000');
         });
 
-        it('keeps host and scheme from endpoint when useSsl is true', () => {
-            expect(s3Adapter.getEndpointUrl('http://minio.local:9000', true)).toBe('https://minio.local:9000');
+        it('preserves an explicit https scheme', () => {
+            expect(s3Adapter.getEndpointUrl('https://nbg1.your-objectstorage.com')).toBe('https://nbg1.your-objectstorage.com');
+        });
+
+        it('detects whether the normalized endpoint is secure', () => {
+            expect(s3Adapter.isSecureEndpoint('nbg1.your-objectstorage.com')).toBe(true);
+            expect(s3Adapter.isSecureEndpoint('http://minio.local:9000')).toBe(false);
         });
     });
 
@@ -23,7 +28,6 @@ describe('AwsS3Adapter', () => {
             accessKeyId: 'access-key',
             secretKey: 'secret-key',
             endpoint: 'nbg1.your-objectstorage.com',
-            useSsl: true,
             forcePathStyle: false,
         };
 

--- a/src/server/adapter/aws-s3.adapter.unit.spec.ts
+++ b/src/server/adapter/aws-s3.adapter.unit.spec.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest';
+import s3Adapter from './aws-s3.adapter';
+
+describe('AwsS3Adapter', () => {
+
+    describe('getEndpointUrl', () => {
+        it('adds https scheme when useSsl is true and endpoint has no scheme', () => {
+            expect(s3Adapter.getEndpointUrl('nbg1.your-objectstorage.com', true)).toBe('https://nbg1.your-objectstorage.com');
+        });
+
+        it('keeps host and switches to http when useSsl is false', () => {
+            expect(s3Adapter.getEndpointUrl('https://nbg1.your-objectstorage.com', false)).toBe('http://nbg1.your-objectstorage.com');
+        });
+
+        it('keeps host and scheme from endpoint when useSsl is true', () => {
+            expect(s3Adapter.getEndpointUrl('http://minio.local:9000', true)).toBe('https://minio.local:9000');
+        });
+    });
+
+    describe('getS3Client', () => {
+        const target = {
+            region: 'nbg1',
+            accessKeyId: 'access-key',
+            secretKey: 'secret-key',
+            endpoint: 'nbg1.your-objectstorage.com',
+            useSsl: true,
+            forcePathStyle: false,
+        };
+
+        it('creates an S3 client for a virtual-hosted style target', () => {
+            const client = s3Adapter.getS3Client(target);
+            expect(client).toBeDefined();
+        });
+
+        it('creates an S3 client for a path-style target', () => {
+            const client = s3Adapter.getS3Client({ ...target, forcePathStyle: true });
+            expect(client).toBeDefined();
+        });
+    });
+});

--- a/src/server/services/aws-s3.service.ts
+++ b/src/server/services/aws-s3.service.ts
@@ -1,4 +1,4 @@
-import { DeleteObjectCommand, GetObjectCommand, HeadBucketCommand, ListObjectsV2Command, PutObjectCommand } from "@aws-sdk/client-s3";
+import { DeleteObjectCommand, GetObjectCommand, HeadBucketCommand, ListObjectsV2Command, PutObjectCommand, type _Object } from "@aws-sdk/client-s3";
 import { S3Target } from "@prisma/client";
 import s3Adapter from "../adapter/aws-s3.adapter";
 import { createReadStream } from "fs";
@@ -21,11 +21,19 @@ export class S3Service {
 
     async listFiles(s3Target: S3Target) {
         const client = s3Adapter.getS3Client(s3Target);
-        const command = new ListObjectsV2Command({
-            Bucket: s3Target.bucketName,
-        });
-        const output = await client.send(command);
-        return output.Contents ?? [];
+        const fileKeys: _Object[] = [];
+        let continuationToken: string | undefined;
+
+        do {
+            const output = await client.send(new ListObjectsV2Command({
+                Bucket: s3Target.bucketName,
+                ContinuationToken: continuationToken,
+            }));
+            fileKeys.push(...(output.Contents ?? []));
+            continuationToken = output.IsTruncated ? output.NextContinuationToken : undefined;
+        } while (continuationToken);
+
+        return fileKeys;
     }
 
     async deleteFile(s3Target: S3Target, fileName: string) {

--- a/src/server/services/aws-s3.service.unit.spec.ts
+++ b/src/server/services/aws-s3.service.unit.spec.ts
@@ -1,0 +1,36 @@
+vi.mock('../adapter/aws-s3.adapter', () => ({
+    default: {
+        getS3Client: vi.fn(),
+    },
+}));
+
+import s3Adapter from '../adapter/aws-s3.adapter';
+import { S3Service } from './aws-s3.service';
+
+describe('S3Service.listFiles', () => {
+    const target = { bucketName: 'backups' } as any;
+
+    it('loads every ListObjectsV2 page', async () => {
+        const send = vi.fn()
+            .mockResolvedValueOnce({
+                Contents: [{ Key: 'backup-001' }],
+                IsTruncated: true,
+                NextContinuationToken: 'next-page',
+            })
+            .mockResolvedValueOnce({
+                Contents: [{ Key: 'backup-1001' }],
+                IsTruncated: false,
+            });
+        vi.mocked(s3Adapter.getS3Client).mockReturnValue({ send } as any);
+
+        await expect(new S3Service().listFiles(target)).resolves.toEqual([
+            { Key: 'backup-001' },
+            { Key: 'backup-1001' },
+        ]);
+        expect(send).toHaveBeenCalledTimes(2);
+        expect(send.mock.calls[1][0].input).toMatchObject({
+            Bucket: 'backups',
+            ContinuationToken: 'next-page',
+        });
+    });
+});

--- a/src/server/services/registry.service.ts
+++ b/src/server/services/registry.service.ts
@@ -8,6 +8,7 @@ import { S3Target } from "@prisma/client";
 import s3TargetService from "./s3-target.service";
 import clusterService from "./cluster.service";
 import { ServiceException } from "@/shared/model/service.exception.model";
+import s3Adapter from "../adapter/aws-s3.adapter";
 
 const REGISTRY_NODE_PORT = 30100;
 const REGISTRY_CONTAINER_PORT = 5000;
@@ -40,7 +41,7 @@ class RegistryService {
             throw new Error('Cannot run garbage collection, because registry is not running.');
         }
         console.log("Running garbage collection...");
-        await podService.runCommandInPod(BUILD_NAMESPACE, pods[0].podName, pods[0].containerName, ['bin/registry', 'garbage-collect', '/etc/docker/registry/config.yml']);
+        await podService.runCommandInPod(BUILD_NAMESPACE, pods[0].podName, pods[0].containerName, ['bin/registry', 'garbage-collect', '/etc/distribution/config.yml']);
         console.log("Garbage collection completed.");
     }
 
@@ -224,12 +225,12 @@ class RegistryService {
                         containers: [
                             {
                                 name: deploymentName,
-                                image: 'registry:2.8',
+                                image: 'registry:3.1.1',
                                 volumeMounts: [
                                     ...localStorageVolumeMount,
                                     {
                                         name: REGISTRY_CONFIG_MAP_NAME,
-                                        mountPath: '/etc/docker/registry',
+                                        mountPath: '/etc/distribution',
                                         readOnly: true,
                                     }
                                 ],
@@ -268,9 +269,13 @@ class RegistryService {
     secretkey: ${s3Target.secretKey}
     region: ${s3Target.region}
     bucket: ${s3Target.bucketName}
+    secure: ${s3Target.useSsl}
+    v4auth: ${s3Target.v4Auth}
     loglevel: debug`;
             if (s3Target.endpoint) {
-                storageS3provider += `\n    regionendpoint: ${s3Target.endpoint}`;
+                storageS3provider += `
+    regionendpoint: ${s3Adapter.getEndpointUrl(s3Target.endpoint, s3Target.useSsl)}
+    forcepathstyle: ${s3Target.forcePathStyle}`;
             }
             storageProvider = storageS3provider;
         } else {

--- a/src/server/services/registry.service.ts
+++ b/src/server/services/registry.service.ts
@@ -269,12 +269,12 @@ class RegistryService {
     secretkey: ${s3Target.secretKey}
     region: ${s3Target.region}
     bucket: ${s3Target.bucketName}
-    secure: ${s3Target.useSsl}
+    secure: ${s3Adapter.isSecureEndpoint(s3Target.endpoint)}
     v4auth: ${s3Target.v4Auth}
     loglevel: debug`;
             if (s3Target.endpoint) {
                 storageS3provider += `
-    regionendpoint: ${s3Adapter.getEndpointUrl(s3Target.endpoint, s3Target.useSsl)}
+    regionendpoint: ${s3Adapter.getEndpointUrl(s3Target.endpoint)}
     forcepathstyle: ${s3Target.forcePathStyle}`;
             }
             storageProvider = storageS3provider;

--- a/src/server/services/s3-target.service.ts
+++ b/src/server/services/s3-target.service.ts
@@ -40,6 +40,17 @@ class S3TargetService {
         });
     }
 
+    async existsById(id: string) {
+        return !!await dataAccess.client.s3Target.findUnique({
+            where: {
+                id
+            },
+            select: {
+                id: true
+            }
+        });
+    }
+
     async save(item: Prisma.S3TargetUncheckedCreateInput | Prisma.S3TargetUncheckedUpdateInput) {
         let savedItem: S3Target;
         try {

--- a/src/server/services/standalone-services/backup.service.ts
+++ b/src/server/services/standalone-services/backup.service.ts
@@ -216,7 +216,7 @@ class BackupService {
         return { backupInfoModels, backupsVolumesWithoutActualBackups };
     }
 
-    private async listAndParseBackupFiles(s3Target: { id: string; createdAt: Date; updatedAt: Date; name: string; bucketName: string; endpoint: string; region: string; accessKeyId: string; secretKey: string; }) {
+    private async listAndParseBackupFiles(s3Target: S3Target) {
         const fileKeys = await s3Service.listFiles(s3Target);
         const backupData = fileKeys.filter(x => {
             if (!x.Key) {

--- a/src/server/services/standalone-services/database-backup-services/mariadb-backup.service.ts
+++ b/src/server/services/standalone-services/database-backup-services/mariadb-backup.service.ts
@@ -1,4 +1,5 @@
 import k3s from "../../../adapter/kubernetes-api.adapter";
+import s3Adapter from "../../../adapter/aws-s3.adapter";
 import { V1Job } from "@kubernetes/client-node";
 import { Constants } from "../../../../shared/utils/constants";
 import { AppTemplateUtils } from "../../../utils/app-template.utils";
@@ -28,7 +29,7 @@ class MariaDbBackupService {
         console.log(`MariaDB/MySQL Database: ${dbCredentials.databaseName}`);
         console.log(`S3 Key: ${s3Key}`);
 
-        const endpoint = backupVolume.target.endpoint.includes('http') ? backupVolume.target.endpoint : `https://${backupVolume.target.endpoint}`;
+        const endpoint = s3Adapter.getEndpointUrl(backupVolume.target.endpoint, backupVolume.target.useSsl);
         console.log(`S3 Endpoint: ${endpoint}`);
 
         const imageTag = process.env.QS_VERSION?.includes('canary') || process.env.NODE_ENV !== 'production' ? 'canary' : 'latest';
@@ -98,6 +99,14 @@ class MariaDbBackupService {
                                     {
                                         name: "S3_REGION",
                                         value: backupVolume.target.region
+                                    },
+                                    {
+                                        name: "S3_FORCE_PATH_STYLE",
+                                        value: String(backupVolume.target.forcePathStyle)
+                                    },
+                                    {
+                                        name: "S3_V4AUTH",
+                                        value: String(backupVolume.target.v4Auth)
                                     },
                                     {
                                         name: "S3_KEY",

--- a/src/server/services/standalone-services/database-backup-services/mariadb-backup.service.ts
+++ b/src/server/services/standalone-services/database-backup-services/mariadb-backup.service.ts
@@ -29,7 +29,7 @@ class MariaDbBackupService {
         console.log(`MariaDB/MySQL Database: ${dbCredentials.databaseName}`);
         console.log(`S3 Key: ${s3Key}`);
 
-        const endpoint = s3Adapter.getEndpointUrl(backupVolume.target.endpoint, backupVolume.target.useSsl);
+        const endpoint = s3Adapter.getEndpointUrl(backupVolume.target.endpoint);
         console.log(`S3 Endpoint: ${endpoint}`);
 
         const imageTag = process.env.QS_VERSION?.includes('canary') || process.env.NODE_ENV !== 'production' ? 'canary' : 'latest';

--- a/src/server/services/standalone-services/database-backup-services/mongodb-backup.service.ts
+++ b/src/server/services/standalone-services/database-backup-services/mongodb-backup.service.ts
@@ -1,4 +1,5 @@
 import k3s from "../../../adapter/kubernetes-api.adapter";
+import s3Adapter from "../../../adapter/aws-s3.adapter";
 import { V1Job } from "@kubernetes/client-node";
 import { Constants } from "../../../../shared/utils/constants";
 import { AppTemplateUtils } from "../../../utils/app-template.utils";
@@ -28,7 +29,7 @@ class MongoDbBackupService {
         console.log(`MongoDB URI: ${mongodbUri.replace(dbCredentials.password, '***')}`);
         console.log(`S3 Key: ${s3Key}`);
 
-        const endpoint = backupVolume.target.endpoint.includes('http') ? backupVolume.target.endpoint : `https://${backupVolume.target.endpoint}`;
+        const endpoint = s3Adapter.getEndpointUrl(backupVolume.target.endpoint, backupVolume.target.useSsl);
         console.log(`S3 Endpoint: ${endpoint}`);
 
         const imageTag = process.env.QS_VERSION?.includes('canary') || process.env.NODE_ENV !== 'production' ? 'canary' : 'latest';
@@ -82,6 +83,14 @@ class MongoDbBackupService {
                                     {
                                         name: "S3_REGION",
                                         value: backupVolume.target.region
+                                    },
+                                    {
+                                        name: "S3_FORCE_PATH_STYLE",
+                                        value: String(backupVolume.target.forcePathStyle)
+                                    },
+                                    {
+                                        name: "S3_V4AUTH",
+                                        value: String(backupVolume.target.v4Auth)
                                     },
                                     {
                                         name: "S3_KEY",

--- a/src/server/services/standalone-services/database-backup-services/mongodb-backup.service.ts
+++ b/src/server/services/standalone-services/database-backup-services/mongodb-backup.service.ts
@@ -29,7 +29,7 @@ class MongoDbBackupService {
         console.log(`MongoDB URI: ${mongodbUri.replace(dbCredentials.password, '***')}`);
         console.log(`S3 Key: ${s3Key}`);
 
-        const endpoint = s3Adapter.getEndpointUrl(backupVolume.target.endpoint, backupVolume.target.useSsl);
+        const endpoint = s3Adapter.getEndpointUrl(backupVolume.target.endpoint);
         console.log(`S3 Endpoint: ${endpoint}`);
 
         const imageTag = process.env.QS_VERSION?.includes('canary') || process.env.NODE_ENV !== 'production' ? 'canary' : 'latest';

--- a/src/server/services/standalone-services/database-backup-services/postgres-backup.service.ts
+++ b/src/server/services/standalone-services/database-backup-services/postgres-backup.service.ts
@@ -1,4 +1,5 @@
 import k3s from "../../../adapter/kubernetes-api.adapter";
+import s3Adapter from "../../../adapter/aws-s3.adapter";
 import { V1Job } from "@kubernetes/client-node";
 import { Constants } from "../../../../shared/utils/constants";
 import { AppTemplateUtils } from "../../../utils/app-template.utils";
@@ -28,7 +29,7 @@ class PostgresBackupService {
         console.log(`PostgreSQL Database: ${dbCredentials.databaseName}`);
         console.log(`S3 Key: ${s3Key}`);
 
-        const endpoint = backupVolume.target.endpoint.includes('http') ? backupVolume.target.endpoint : `https://${backupVolume.target.endpoint}`;
+        const endpoint = s3Adapter.getEndpointUrl(backupVolume.target.endpoint, backupVolume.target.useSsl);
         console.log(`S3 Endpoint: ${endpoint}`);
 
         const imageTag = process.env.QS_VERSION?.includes('canary') || process.env.NODE_ENV !== 'production' ? 'canary' : 'latest';
@@ -99,6 +100,14 @@ class PostgresBackupService {
                                     {
                                         name: "S3_REGION",
                                         value: backupVolume.target.region
+                                    },
+                                    {
+                                        name: "S3_FORCE_PATH_STYLE",
+                                        value: String(backupVolume.target.forcePathStyle)
+                                    },
+                                    {
+                                        name: "S3_V4AUTH",
+                                        value: String(backupVolume.target.v4Auth)
                                     },
                                     {
                                         name: "S3_KEY",

--- a/src/server/services/standalone-services/database-backup-services/postgres-backup.service.ts
+++ b/src/server/services/standalone-services/database-backup-services/postgres-backup.service.ts
@@ -29,7 +29,7 @@ class PostgresBackupService {
         console.log(`PostgreSQL Database: ${dbCredentials.databaseName}`);
         console.log(`S3 Key: ${s3Key}`);
 
-        const endpoint = s3Adapter.getEndpointUrl(backupVolume.target.endpoint, backupVolume.target.useSsl);
+        const endpoint = s3Adapter.getEndpointUrl(backupVolume.target.endpoint);
         console.log(`S3 Endpoint: ${endpoint}`);
 
         const imageTag = process.env.QS_VERSION?.includes('canary') || process.env.NODE_ENV !== 'production' ? 'canary' : 'latest';

--- a/src/shared/model/generated-zod/s3target.ts
+++ b/src/shared/model/generated-zod/s3target.ts
@@ -10,7 +10,6 @@ export const S3TargetModel = z.object({
   region: z.string(),
   accessKeyId: z.string(),
   secretKey: z.string(),
-  useSsl: z.boolean(),
   v4Auth: z.boolean(),
   forcePathStyle: z.boolean(),
   createdAt: z.date(),

--- a/src/shared/model/generated-zod/s3target.ts
+++ b/src/shared/model/generated-zod/s3target.ts
@@ -10,6 +10,9 @@ export const S3TargetModel = z.object({
   region: z.string(),
   accessKeyId: z.string(),
   secretKey: z.string(),
+  useSsl: z.boolean(),
+  v4Auth: z.boolean(),
+  forcePathStyle: z.boolean(),
   createdAt: z.date(),
   updatedAt: z.date(),
 })

--- a/src/shared/model/s3-target-edit.model.ts
+++ b/src/shared/model/s3-target-edit.model.ts
@@ -8,6 +8,9 @@ export const s3TargetEditZodModel = z.object({
   region: z.string().trim().min(1),
   accessKeyId: z.string().trim().min(1),
   secretKey: z.string().trim().min(1),
+  useSsl: z.boolean().optional().default(true),
+  v4Auth: z.boolean().optional().default(true),
+  forcePathStyle: z.boolean().optional().default(false),
 })
 
 export type S3TargetEditModel = z.infer<typeof s3TargetEditZodModel>;

--- a/src/shared/model/s3-target-edit.model.ts
+++ b/src/shared/model/s3-target-edit.model.ts
@@ -8,7 +8,6 @@ export const s3TargetEditZodModel = z.object({
   region: z.string().trim().min(1),
   accessKeyId: z.string().trim().min(1),
   secretKey: z.string().trim().min(1),
-  useSsl: z.boolean().optional().default(true),
   v4Auth: z.boolean().optional().default(true),
   forcePathStyle: z.boolean().optional().default(false),
 })


### PR DESCRIPTION
Fixes #106

## What
Registry S3 storage for S3-compatible providers (e.g. Hetzner Object Storage) missed required Docker Distribution options (`secure`, `v4auth`, `forcepathstyle`, scheme-full `regionendpoint`). Manual env patches were lost whenever QuickStack redeployed the registry.

Also upgraded the internal registry image from `registry:2.8` to `registry:3.1.1`.

## Changes
- **S3 Target model**: new options `useSsl` (default true), `v4Auth` (default true), `forcePathStyle` (default false) + Prisma migration. Existing targets keep working via defaults.
- **UI**: advanced option checkboxes in the S3 target edit dialog.
- **aws-s3.adapter**: endpoint scheme derived from `useSsl`, `forcePathStyle` applied -> connection test / backups behave like the registry.
- **registry.service**: generated config now emits `regionendpoint` with scheme plus `secure`, `v4auth`, `forcepathstyle` from the selected S3 target.
- **Registry v3 upgrade**: image `registry:3.1.1`, config path moved to `/etc/distribution/config.yml` (mount + garbage-collect updated). No env changes required.
- **Registry redeploy on startup**: bootstrap route `/api/init` now always force-redeploys the registry (same as the Maintenance button), so storage settings/image version are never stale after a QuickStack restart.
- **DB backup containers** (`quickstack/job-backup-{mariadb,postgres,mongodb}`): job env now passes `S3_FORCE_PATH_STYLE` + `S3_V4AUTH` and derives the endpoint scheme from `useSsl`; the `additional-containers/*/backup.sh` scripts configure AWS CLI `addressing_style`/`signature_version` accordingly.

## Notes
- Migration trimmed to the S3Target change; a pre-existing `User` table drift on `main` was intentionally not included.
- `quickstack/job-backup-*` images are not built in this repo and must be rebuilt/released separately for the DB backup container change to take effect.
- Checks: `tsc` (app + server), `yarn lint`, 5 unit tests pass.
