### PR TITLE
fix: Can't rename existing projects

### DIFF
--- a/src/app/project/[projectId]/actions.ts
+++ b/src/app/project/[projectId]/actions.ts
@@ -1,9 +1,9 @@
 'use server'
 
 import { SuccessActionResult } from "@/shared/model/server-action-error-return.model";
+import { z } from "zod";
 import appService from "@/server/services/app.service";
 import { getAuthUserSession, isAuthorizedDeleteForProject, saveFormAction, simpleAction } from "@/server/utils/action-wrapper.utils";
-import { z } from "zod";
 import appTemplateService from "@/server/services/app-template.service";
 import { AppTemplateModel, appTemplateZodModel } from "@/shared/model/app-template.model";
 import { ServiceException } from "@/shared/model/service.exception.model";
@@ -20,6 +20,7 @@ import agentService from "@/server/services/agent.service";
 import llmGatewayService from "@/server/services/llm-gateway.service";
 import agentTemplateService from "@/server/services/agent-template.service";
 import { AgentTemplateModel, agentTemplateZodModel } from "@/shared/model/agent-template.model";
+import { RenameAgentModel, renameAgentZodModel } from "@/shared/model/rename-agent.model";
 
 const createAppSchema = z.object({
     appName: z.string().min(1)
@@ -85,6 +86,21 @@ export const createAgent = async (agentName: string, projectId: string, llmGatew
         });
 
         return new SuccessActionResult(returnData, 'Agent created successfully.');
+    });
+
+export const renameAgent = async (_prevState: unknown, inputData: RenameAgentModel, agentId: string) =>
+    saveFormAction(inputData, renameAgentZodModel, async (validatedData) => {
+        const session = await getAuthUserSession();
+        const identity: RequesterIdentity = { type: 'session', session };
+        const agent = await agentService.getById(agentId);
+        ensureCreateProjectWorkloadInProject(identity, agent.projectId);
+
+        const returnData = await agentService.saveAgent({
+            id: agent.id,
+            name: validatedData.name,
+        });
+
+        return new SuccessActionResult(returnData, 'Agent renamed successfully.');
     });
 
 export const getLlmGateways = async () =>

--- a/src/app/project/[projectId]/agent-list-client.tsx
+++ b/src/app/project/[projectId]/agent-list-client.tsx
@@ -3,15 +3,16 @@
 import { SimpleDataTable } from "@/components/custom/simple-data-table";
 import { UserSession } from "@/shared/model/sim-session.model";
 import { AgentExtendedModel } from "@/shared/model/agent-extended.model";
-import { Bot, Eye, MoreHorizontal, Trash } from "lucide-react";
+import { Bot, Edit2, Eye, MoreHorizontal, Trash } from "lucide-react";
 import { UserGroupUtils } from "@/shared/utils/role.utils";
 import CreateProjectActions from "./create-project-actions";
 import Link from "next/link";
 import { Button } from "@/components/ui/button";
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuLabel, DropdownMenuSeparator, DropdownMenuTrigger } from "@/components/ui/dropdown-menu";
-import { useConfirmDialog } from "@/frontend/states/zustand.states";
+import { useConfirmDialog, useDialog } from "@/frontend/states/zustand.states";
 import { Toast } from "@/frontend/utils/toast.utils";
 import { deleteAgent } from "./actions";
+import { RenameAgentDialog } from "./rename-agent-dialog";
 import {
     Empty,
     EmptyContent,
@@ -31,6 +32,7 @@ export default function AgentListClient({ agents, session, projectId }: AgentLis
     const canCreate = UserGroupUtils.sessionCanCreateProjectWorkloadsForProject(session, projectId);
     const canDelete = UserGroupUtils.sessionCanDeleteAgentsForProject(session, projectId);
     const { openConfirmDialog } = useConfirmDialog();
+    const { openDialog } = useDialog();
 
     if (agents.length === 0 && !canCreate) {
         return (
@@ -100,6 +102,11 @@ export default function AgentListClient({ agents, session, projectId }: AgentLis
                                         <Eye /> <span>Show Agent Details</span>
                                     </DropdownMenuItem>
                                 </Link>
+                                {canCreate && (
+                                    <DropdownMenuItem onClick={() => openDialog(<RenameAgentDialog agent={item} />, { maxWidth: 'max-w-md' })}>
+                                        <Edit2 /> <span>Rename Agent</span>
+                                    </DropdownMenuItem>
+                                )}
                                 {canDelete && (
                                     <>
                                         <DropdownMenuSeparator />

--- a/src/app/project/[projectId]/rename-agent-dialog.tsx
+++ b/src/app/project/[projectId]/rename-agent-dialog.tsx
@@ -1,0 +1,70 @@
+'use client';
+
+import { Button } from "@/components/ui/button";
+import { SubmitButton } from "@/components/custom/submit-button";
+import { DialogDescription, DialogFooter, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from "@/components/ui/form";
+import { Input } from "@/components/ui/input";
+import { useDialogContext } from "@/frontend/states/dialog-context";
+import { FormUtils } from "@/frontend/utils/form.utilts";
+import { AgentExtendedModel } from "@/shared/model/agent-extended.model";
+import { RenameAgentModel, renameAgentZodModel } from "@/shared/model/rename-agent.model";
+import { ServerActionResult } from "@/shared/model/server-action-error-return.model";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useRouter } from "next/navigation";
+import { useActionState, useEffect } from "react";
+import { useForm } from "react-hook-form";
+import type { z } from "zod";
+import { toast } from "sonner";
+import { renameAgent } from "./actions";
+import { Agent } from "@prisma/client";
+
+export function RenameAgentDialog({ agent }: { agent: AgentExtendedModel }) {
+    const { closeDialog } = useDialogContext();
+    const router = useRouter();
+    const form = useForm<z.input<typeof renameAgentZodModel>, unknown, z.output<typeof renameAgentZodModel>>({
+        resolver: zodResolver(renameAgentZodModel),
+        defaultValues: { name: agent.name },
+    });
+    const [state, formAction] = useActionState((state: ServerActionResult<RenameAgentModel, Agent>, payload: RenameAgentModel) => renameAgent(state, payload, agent.id),
+        FormUtils.getInitialFormState<typeof renameAgentZodModel>(),
+    );
+
+    useEffect(() => {
+        if (state.status === 'success') {
+            toast.success('Agent renamed successfully.');
+            closeDialog();
+            router.refresh();
+        }
+        FormUtils.mapValidationErrorsToForm<typeof renameAgentZodModel>(state, form);
+    }, [closeDialog, form, router, state]);
+
+    const submit = () => {
+        form.handleSubmit((data) => formAction(data))();
+    };
+
+    return (
+        <Form {...form}>
+            <form action={submit}>
+                <DialogHeader>
+                    <DialogTitle>Rename Agent</DialogTitle>
+                    <DialogDescription>Choose a new display name for this agent.</DialogDescription>
+                </DialogHeader>
+                <div className="py-4">
+                    <FormField control={form.control} name="name" render={({ field }) => (
+                        <FormItem>
+                            <FormLabel>Name</FormLabel>
+                            <FormControl><Input autoFocus {...field} /></FormControl>
+                            <FormMessage />
+                        </FormItem>
+                    )} />
+                    <p className="text-red-500">{state.status === 'error' && !state.errors ? state.message : ''}</p>
+                </div>
+                <DialogFooter>
+                    <SubmitButton>Rename</SubmitButton>
+                    <Button type="button" variant="outline" onClick={() => closeDialog()}>Cancel</Button>
+                </DialogFooter>
+            </form>
+        </Form>
+    );
+}

--- a/src/app/projects/edit-project-dialog.tsx
+++ b/src/app/projects/edit-project-dialog.tsx
@@ -2,8 +2,6 @@
 
 import { Button } from '@/components/ui/button';
 import {
-    Dialog,
-    DialogContent,
     DialogDescription,
     DialogFooter,
     DialogHeader,
@@ -19,79 +17,83 @@ import {
     SelectValue,
 } from '@/components/ui/select';
 import { Toast } from '@/frontend/utils/toast.utils';
+import { useDialogContext } from '@/frontend/states/dialog-context';
+import { useDialog } from '@/frontend/states/zustand.states';
 import { ProjectType } from '@/shared/model/project-type.model';
 import { Project } from '@prisma/client';
 import { useState } from 'react';
 import { createProject } from './actions';
+
+function EditProjectForm({ existingItem, agentsAvailable }: {
+    existingItem?: Project;
+    agentsAvailable: boolean;
+}) {
+    const { closeDialog } = useDialogContext();
+    const [name, setName] = useState(existingItem?.name ?? '');
+    const [projectType, setProjectType] = useState<ProjectType | undefined>(
+        agentsAvailable ? existingItem?.projectType as ProjectType | undefined : 'APP',
+    );
+
+    const submit = async () => {
+        if (!name.trim() || !projectType) return;
+        await Toast.fromAction(() => createProject(name.trim(), projectType, existingItem?.id));
+        closeDialog();
+    };
+
+    return <>
+        <DialogHeader>
+            <DialogTitle>{existingItem ? 'Edit Project' : 'Create Project'}</DialogTitle>
+            <DialogDescription>
+                {existingItem
+                    ? 'Rename this Project. Project Type cannot be changed.'
+                    : 'Choose the workload type this Project will contain.'}
+            </DialogDescription>
+        </DialogHeader>
+        <div className="grid gap-4 py-4">
+            <div className="grid gap-2">
+                <Label htmlFor="project-name">Name</Label>
+                <Input
+                    id="project-name"
+                    value={name}
+                    onChange={(event) => setName(event.target.value)}
+                />
+            </div>
+            <div className="grid gap-2">
+                <Label>Project Type</Label>
+                <Select
+                    disabled={!!existingItem}
+                    value={projectType}
+                    onValueChange={(value) => setProjectType(value as ProjectType)}
+                >
+                    <SelectTrigger>
+                        <SelectValue placeholder="Select Project Type" />
+                    </SelectTrigger>
+                    <SelectContent>
+                        <SelectItem value="APP">App</SelectItem>
+                        {agentsAvailable && <SelectItem value="AGENT">Agent</SelectItem>}
+                    </SelectContent>
+                </Select>
+            </div>
+        </div>
+        <DialogFooter>
+            <Button disabled={!name.trim() || !projectType} onClick={submit}>
+                {existingItem ? 'Save Project' : 'Create Project'}
+            </Button>
+            <Button variant="secondary" onClick={() => closeDialog()}>Cancel</Button>
+        </DialogFooter>
+    </>;
+}
 
 export function EditProjectDialog({ children, existingItem, agentsAvailable }: {
     children?: React.ReactNode;
     existingItem?: Project;
     agentsAvailable: boolean;
 }) {
-    const [open, setOpen] = useState(false);
-    const [name, setName] = useState(existingItem?.name ?? '');
-    const [projectType, setProjectType] = useState<ProjectType | undefined>(
-        agentsAvailable ? existingItem?.projectType as ProjectType | undefined : 'APP',
-    );
+    const { openDialog } = useDialog();
 
-    const openDialog = () => {
-        setName(existingItem?.name ?? '');
-        setProjectType(existingItem?.projectType as ProjectType | undefined);
-        setOpen(true);
+    const handleOpen = () => {
+        openDialog(<EditProjectForm existingItem={existingItem} agentsAvailable={agentsAvailable} />, { maxWidth: '425px' });
     };
 
-    const submit = async () => {
-        if (!name.trim() || !projectType) return;
-        await Toast.fromAction(() => createProject(name.trim(), projectType, existingItem?.id));
-        setOpen(false);
-    };
-
-    return <>
-        <div onClick={openDialog}>{children}</div>
-        <Dialog open={open} onOpenChange={setOpen}>
-            <DialogContent className="sm:max-w-[425px]">
-                <DialogHeader>
-                    <DialogTitle>{existingItem ? 'Edit Project' : 'Create Project'}</DialogTitle>
-                    <DialogDescription>
-                        {existingItem
-                            ? 'Rename this Project. Project Type cannot be changed.'
-                            : 'Choose the workload type this Project will contain.'}
-                    </DialogDescription>
-                </DialogHeader>
-                <div className="grid gap-4 py-4">
-                    <div className="grid gap-2">
-                        <Label htmlFor="project-name">Name</Label>
-                        <Input
-                            id="project-name"
-                            value={name}
-                            onChange={(event) => setName(event.target.value)}
-                        />
-                    </div>
-                    <div className="grid gap-2">
-                        <Label>Project Type</Label>
-                        <Select
-                            disabled={!!existingItem}
-                            value={projectType}
-                            onValueChange={(value) => setProjectType(value as ProjectType)}
-                        >
-                            <SelectTrigger>
-                                <SelectValue placeholder="Select Project Type" />
-                            </SelectTrigger>
-                            <SelectContent>
-                                <SelectItem value="APP">App</SelectItem>
-                                {agentsAvailable && <SelectItem value="AGENT">Agent</SelectItem>}
-                            </SelectContent>
-                        </Select>
-                    </div>
-                </div>
-                <DialogFooter>
-                    <Button disabled={!name.trim() || !projectType} onClick={submit}>
-                        {existingItem ? 'Save Project' : 'Create Project'}
-                    </Button>
-                    <Button variant="secondary" onClick={() => setOpen(false)}>Cancel</Button>
-                </DialogFooter>
-            </DialogContent>
-        </Dialog>
-    </>;
+    return <div onClick={handleOpen}>{children}</div>;
 }

--- a/src/shared/model/rename-agent.model.ts
+++ b/src/shared/model/rename-agent.model.ts
@@ -1,0 +1,7 @@
+import { z } from "zod";
+
+export const renameAgentZodModel = z.object({
+    name: z.string().trim().min(1),
+});
+
+export type RenameAgentModel = z.infer<typeof renameAgentZodModel>;


### PR DESCRIPTION
## Fixes #120

**Root cause:** `EditProjectDialog` rendered its own local `<Dialog>` (local `useState`) directly inside the row's `DropdownMenuContent`. Clicking "Edit Project Name" opened the dialog, but the `DropdownMenuItem` click also closes the dropdown — unmounting `DropdownMenuContent` and the whole `EditProjectDialog` tree with its Dialog. So the dialog opened and instantly disappeared.

**Fix:** Migrated `EditProjectDialog` to the trigger + dialog-content pattern backed by the global `useDialog` store (`GenericDialog`, mounted at root layout). The dialog content now lives outside the dropdown, so it stays open until the user cancels or saves. Same pattern already used by `EditAppDialog`/row-menu rename for apps.

Call sites unchanged (`projects-table.tsx`, `project-page.tsx`, `sidebar-client.tsx`) — same component name/props.

**Testing:** Ran tsc on changed file (no errors; repo-wide tsc shows only pre-existing backup-service errors) and eslint. No UI test infra for these components; verified pattern parity with existing global-dialog usages.