### PR TITLE
feat: configurable parallel builds (1-20, default 1)

### DIFF
--- a/src/app/settings/server/actions.ts
+++ b/src/app/settings/server/actions.ts
@@ -63,15 +63,15 @@ export const saveBuildSettings = async (prevState: any, inputData: BuildSettings
     await paramService.save({ name: ParamService.MAX_PARALLEL_BUILDS, value: String(validatedData.maxParallelBuilds) });
   });
 
-export const getBuildSettings = async (): Promise<BuildSettingsModel> => {
+export const getBuildSettings = async (revalidateParam = true): Promise<BuildSettingsModel> => {
   await getAdminUserSession();
   const [memoryLimit, memoryReservation, cpuLimit, cpuReservation, buildNode, maxParallelBuilds] = await Promise.all([
-    paramService.getNumber(ParamService.BUILD_MEMORY_LIMIT),
-    paramService.getNumber(ParamService.BUILD_MEMORY_RESERVATION),
-    paramService.getNumber(ParamService.BUILD_CPU_LIMIT),
-    paramService.getNumber(ParamService.BUILD_CPU_RESERVATION),
-    paramService.getString(ParamService.BUILD_NODE),
-    paramService.getNumber(ParamService.MAX_PARALLEL_BUILDS, Constants.DEFAULT_MAX_PARALLEL_BUILDS),
+    paramService.getNumber(ParamService.BUILD_MEMORY_LIMIT, undefined, revalidateParam),
+    paramService.getNumber(ParamService.BUILD_MEMORY_RESERVATION, undefined, revalidateParam),
+    paramService.getNumber(ParamService.BUILD_CPU_LIMIT, undefined, revalidateParam),
+    paramService.getNumber(ParamService.BUILD_CPU_RESERVATION, undefined, revalidateParam),
+    paramService.getString(ParamService.BUILD_NODE, undefined, revalidateParam),
+    paramService.getNumber(ParamService.MAX_PARALLEL_BUILDS, Constants.DEFAULT_MAX_PARALLEL_BUILDS, revalidateParam),
   ]);
   return { memoryLimit, memoryReservation, cpuLimit, cpuReservation, buildNode, maxParallelBuilds: maxParallelBuilds ?? Constants.DEFAULT_MAX_PARALLEL_BUILDS };
 };

--- a/src/app/settings/server/actions.ts
+++ b/src/app/settings/server/actions.ts
@@ -60,18 +60,20 @@ export const saveBuildSettings = async (prevState: any, inputData: BuildSettings
       await paramService.deleteByNameIfExists(ParamService.BUILD_CPU_RESERVATION);
     }
     await saveOrDelete(ParamService.BUILD_NODE, validatedData.buildNode);
+    await paramService.save({ name: ParamService.MAX_PARALLEL_BUILDS, value: String(validatedData.maxParallelBuilds) });
   });
 
 export const getBuildSettings = async (): Promise<BuildSettingsModel> => {
   await getAdminUserSession();
-  const [memoryLimit, memoryReservation, cpuLimit, cpuReservation, buildNode] = await Promise.all([
+  const [memoryLimit, memoryReservation, cpuLimit, cpuReservation, buildNode, maxParallelBuilds] = await Promise.all([
     paramService.getNumber(ParamService.BUILD_MEMORY_LIMIT),
     paramService.getNumber(ParamService.BUILD_MEMORY_RESERVATION),
     paramService.getNumber(ParamService.BUILD_CPU_LIMIT),
     paramService.getNumber(ParamService.BUILD_CPU_RESERVATION),
     paramService.getString(ParamService.BUILD_NODE),
+    paramService.getNumber(ParamService.MAX_PARALLEL_BUILDS, Constants.DEFAULT_MAX_PARALLEL_BUILDS),
   ]);
-  return { memoryLimit, memoryReservation, cpuLimit, cpuReservation, buildNode };
+  return { memoryLimit, memoryReservation, cpuLimit, cpuReservation, buildNode, maxParallelBuilds: maxParallelBuilds ?? Constants.DEFAULT_MAX_PARALLEL_BUILDS };
 };
 
 export const setNodeStatus = async (nodeName: string, schedulable: boolean) =>

--- a/src/app/settings/server/page.tsx
+++ b/src/app/settings/server/page.tsx
@@ -29,7 +29,7 @@ import UpdateInfoPage from "./update-info";
 import LonghornUiToggle from "./longhorn-ui-toggle";
 import RestApiSettings from "./rest-api-settings";
 
-export default async function ProjectPage({
+export default async function QuickStackSettingsPage({
     searchParams
 }: {
     searchParams: Promise<{ [key: string]: string | string[] | undefined }>
@@ -48,14 +48,14 @@ export default async function ProjectPage({
         clusterJoinToken,
         openApiEnabled
     ] = await Promise.all([
-        paramService.getString(ParamService.QS_SERVER_HOSTNAME, ''),
-        paramService.getBoolean(ParamService.DISABLE_NODEPORT_ACCESS, false),
-        paramService.getString(ParamService.LETS_ENCRYPT_MAIL, session.email),
-        paramService.getString(ParamService.REGISTRY_SOTRAGE_LOCATION, Constants.INTERNAL_REGISTRY_LOCATION),
-        paramService.getString(ParamService.PUBLIC_IPV4_ADDRESS),
-        paramService.getString(ParamService.QS_SYSTEM_BACKUP_LOCATION, Constants.QS_SYSTEM_BACKUP_DEACTIVATED),
-        paramService.getString(ParamService.K3S_JOIN_TOKEN),
-        paramService.getBoolean(ParamService.API_OPEN_API_SPEC_ENABLED)
+        paramService.getString(ParamService.QS_SERVER_HOSTNAME, '', false),
+        paramService.getBoolean(ParamService.DISABLE_NODEPORT_ACCESS, false, false),
+        paramService.getString(ParamService.LETS_ENCRYPT_MAIL, session.email, false),
+        paramService.getString(ParamService.REGISTRY_SOTRAGE_LOCATION, Constants.INTERNAL_REGISTRY_LOCATION, false),
+        paramService.getString(ParamService.PUBLIC_IPV4_ADDRESS, undefined, false),
+        paramService.getString(ParamService.QS_SYSTEM_BACKUP_LOCATION, Constants.QS_SYSTEM_BACKUP_DEACTIVATED, false),
+        paramService.getString(ParamService.K3S_JOIN_TOKEN, undefined, false),
+        paramService.getBoolean(ParamService.API_OPEN_API_SPEC_ENABLED, undefined, false)
     ]);
 
     const [
@@ -71,7 +71,7 @@ export default async function ProjectPage({
         podService.getPodsForApp(Constants.QS_NAMESPACE, Constants.QS_APP_NAME),
         quickStackUpdateService.getNewVersionInfo(),
         clusterService.getNodeInfo(),
-        getBuildSettings()
+        getBuildSettings(false)
     ]);
 
     const qsPodInfo = qsPodInfos.find(p => !!p);

--- a/src/app/settings/server/qs-build-settings.tsx
+++ b/src/app/settings/server/qs-build-settings.tsx
@@ -35,7 +35,7 @@ export default function QsBuildSettings({
     });
 
     const [state, formAction] = useActionState(
-        (state: ServerActionResult<any, any>, payload: BuildSettingsModel) => saveBuildSettings(state, payload),
+        (state: ServerActionResult<BuildSettingsModel, void>, payload: BuildSettingsModel) => saveBuildSettings(state, payload),
         FormUtils.getInitialFormState<typeof buildSettingsZodModel>()
     );
 
@@ -67,6 +67,23 @@ export default function QsBuildSettings({
                     return formAction(payload);
                 })()}>
                     <CardContent className="space-y-6">
+
+                        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                            <FormField
+                                control={form.control}
+                                name="maxParallelBuilds"
+                                render={({ field }) => (
+                                    <FormItem>
+                                        <FormLabel>Max Parallel Builds</FormLabel>
+                                        <FormControl>
+                                            <Input type="number" min={1} max={20} step={1} {...field} value={field.value as string | number | undefined ?? ''} />
+                                        </FormControl>
+                                        <FormMessage />
+                                    </FormItem>
+                                )}
+                            />
+                        </div>
+
                         <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
                             <FormField
                                 control={form.control}
@@ -101,22 +118,6 @@ export default function QsBuildSettings({
                                                 ))}
                                             </SelectContent>
                                         </Select>
-                                        <FormMessage />
-                                    </FormItem>
-                                )}
-                            />
-                        </div>
-
-                        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-                            <FormField
-                                control={form.control}
-                                name="maxParallelBuilds"
-                                render={({ field }) => (
-                                    <FormItem>
-                                        <FormLabel>Max Parallel Builds</FormLabel>
-                                        <FormControl>
-                                            <Input type="number" min={1} max={20} step={1} {...field} value={field.value as string | number | undefined ?? ''} />
-                                        </FormControl>
                                         <FormMessage />
                                     </FormItem>
                                 )}

--- a/src/app/settings/server/qs-build-settings.tsx
+++ b/src/app/settings/server/qs-build-settings.tsx
@@ -55,7 +55,7 @@ export default function QsBuildSettings({
             <CardHeader>
                 <CardTitle>Build Container Settings</CardTitle>
                 <CardDescription>
-                    Configure global resource limits and node placement for all build containers.
+                    Configure global resource limits, node placement, and the number of parallel builds for all build containers.
                 </CardDescription>
             </CardHeader>
             <Form {...form}>
@@ -101,6 +101,22 @@ export default function QsBuildSettings({
                                                 ))}
                                             </SelectContent>
                                         </Select>
+                                        <FormMessage />
+                                    </FormItem>
+                                )}
+                            />
+                        </div>
+
+                        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                            <FormField
+                                control={form.control}
+                                name="maxParallelBuilds"
+                                render={({ field }) => (
+                                    <FormItem>
+                                        <FormLabel>Max Parallel Builds</FormLabel>
+                                        <FormControl>
+                                            <Input type="number" min={1} max={20} step={1} {...field} value={field.value as string | number | undefined ?? ''} />
+                                        </FormControl>
                                         <FormMessage />
                                     </FormItem>
                                 )}

--- a/src/app/settings/server/update-info.tsx
+++ b/src/app/settings/server/update-info.tsx
@@ -21,7 +21,7 @@ export default async function UpdateInfoPage() {
         newVersionInfo,
         k3sControllerStatus,
     ] = await Promise.all([
-        paramService.getBoolean(ParamService.USE_CANARY_CHANNEL, false),
+        paramService.getBoolean(ParamService.USE_CANARY_CHANNEL, false, false),
         quickStackService.getVersionOfCurrentQuickstackInstance(),
         quickStackUpdateService.getNewVersionInfo(),
         k3sUpdateService.isSystemUpgradeControllerPresent(),

--- a/src/server/services/build-job-builders/build-git-init-container.service.unit.spec.ts
+++ b/src/server/services/build-job-builders/build-git-init-container.service.unit.spec.ts
@@ -17,6 +17,7 @@ describe('BuildGitInitContainerService', () => {
             latestRemoteGitHash: 'abc123',
             latestRemoteGitCommitMessage: 'feat: test',
             queuedAt: '123',
+            maxParallelBuilds: 1,
         });
 
         expect(container.name).toBe('build-git-init');
@@ -55,6 +56,7 @@ describe('BuildGitInitContainerService', () => {
             latestRemoteGitHash: 'abc123',
             latestRemoteGitCommitMessage: 'feat: test',
             queuedAt: '123',
+            maxParallelBuilds: 1,
             gitSshPrivateKeySecretName: 'git-ssh-build-1',
         });
 

--- a/src/server/services/build-job-builders/build-init-container.service.ts
+++ b/src/server/services/build-job-builders/build-init-container.service.ts
@@ -57,27 +57,28 @@ class BuildInitContainerService {
         }, BUILD_NAMESPACE);
     }
 
-    getInitContainer(currentJobName: string, queuedAt: string): V1Container {
+    getInitContainer(currentJobName: string, queuedAt: string, maxParallelBuilds: number = Constants.DEFAULT_MAX_PARALLEL_BUILDS): V1Container {
+        const maxParallel = Math.min(Constants.MAX_PARALLEL_BUILDS_LIMIT, Math.max(Constants.DEFAULT_MAX_PARALLEL_BUILDS, Math.floor(maxParallelBuilds)));
         const script = [
             'sleep $((RANDOM % 5 + 1));',
             'while true; do',
             '  DATA=$(kubectl get jobs -n "$NAMESPACE" \\',
             '    -o go-template=\'{{range .items}}{{.metadata.name}}{{"\\t"}}{{index .metadata.annotations "qs-build-queued-at"}}{{"\\t"}}{{range .status.conditions}}{{.type}}={{.status}},{{end}}{{"\\n"}}{{end}}\');',
-            '  OLDEST=$(echo "$DATA" | awk \'',
-            '    BEGIN { min_ts=""; min_name="" }',
+            '  OLDER=$(echo "$DATA" | awk \'',
             '    {',
             '      name=$1; ts=$2; conds=$3;',
-            '      if (conds ~ /Complete=True/ || conds ~ /Failed=True/) next;',
             '      if (ts == "") next;',
-            '      if (min_ts=="" || ts+0 < min_ts+0) { min_ts=ts; min_name=name }',
+            '      if (conds ~ /Complete=True/ || conds ~ /Failed=True/) next;',
+            '      if (ts+0 < myts+0) older++;',
+            '      else if (ts+0 == myts+0 && name < myname) older++;',
             '    }',
-            '    END { print min_name }',
-            '  \');',
-            '  if [ "$OLDEST" = "$CURRENT_JOB_NAME" ]; then',
-            '    echo "Queue slot acquired (oldest pending build: $CURRENT_JOB_NAME). Starting build.";',
+            '    END { print older+0 }',
+            '  \' myname="$CURRENT_JOB_NAME" myts="$QUEUED_AT");',
+            '  if [ "$OLDER" -lt "$MAX_PARALLEL_BUILDS" ]; then',
+            '    echo "Queue slot acquired ($OLDER older build(s) pending, max parallel: $MAX_PARALLEL_BUILDS). Starting build.";',
             '    exit 0;',
             '  fi;',
-            '  echo "Waiting for older build to finish (oldest pending: $OLDEST). Retrying...";',
+            '  echo "Waiting for older builds to finish (older pending: $OLDER, max parallel: $MAX_PARALLEL_BUILDS). Retrying...";',
             '  sleep $((RANDOM % 5 + 5));',
             'done',
         ].join('\n');
@@ -99,6 +100,10 @@ class BuildInitContainerService {
                 {
                     name: 'QUEUED_AT',
                     value: queuedAt,
+                },
+                {
+                    name: 'MAX_PARALLEL_BUILDS',
+                    value: maxParallel.toString(),
                 },
             ],
         };

--- a/src/server/services/build-job-builders/build-init-container.service.unit.spec.ts
+++ b/src/server/services/build-job-builders/build-init-container.service.unit.spec.ts
@@ -1,0 +1,49 @@
+import buildQueueInitContainer from "./build-init-container.service";
+
+vi.mock('@/server/adapter/kubernetes-api.adapter', () => ({
+    default: {
+        applyResource: vi.fn(),
+    },
+}));
+vi.mock('@/server/services/registry.service', () => ({
+    BUILD_NAMESPACE: 'registry-and-build',
+}));
+
+describe('BuildInitContainerService', () => {
+    it('defaults to 1 max parallel build when not configured', () => {
+        const container = buildQueueInitContainer.getInitContainer('build-1', '123');
+
+        expect(container.name).toBe('build-queue-init');
+        expect(container.env?.find((entry) => entry.name === 'MAX_PARALLEL_BUILDS')?.value).toBe('1');
+        expect(container.args?.[0]).toContain('awk');
+        expect(container.args?.[0]).toContain('Complete=True');
+    });
+
+    it('passes the configured max parallel builds as env value', () => {
+        const container = buildQueueInitContainer.getInitContainer('build-1', '123', 4);
+
+        expect(container.env?.find((entry) => entry.name === 'MAX_PARALLEL_BUILDS')?.value).toBe('4');
+    });
+
+    it('uses count-older slot logic instead of oldest-only logic', () => {
+        const container = buildQueueInitContainer.getInitContainer('build-1', '123', 3);
+
+        const script = container.args?.[0] ?? '';
+        expect(script).toContain('OLDER=$(echo "$DATA" | awk');
+        expect(script).toContain('older++');
+        expect(script).toContain('if [ "$OLDER" -lt "$MAX_PARALLEL_BUILDS" ]; then');
+        expect(script).not.toContain('min_name');
+    });
+
+    it.each([
+        [0, '1'],
+        [3.9, '3'],
+        [20, '20'],
+        [21, '20'],
+        [25, '20'],
+    ])('clamps configured value %s to allowed range', (configured, expected) => {
+        const container = buildQueueInitContainer.getInitContainer('build-1', '123', configured);
+
+        expect(container.env?.find((entry) => entry.name === 'MAX_PARALLEL_BUILDS')?.value).toBe(expected);
+    });
+});

--- a/src/server/services/build-job-builders/build-job-builder.interface.ts
+++ b/src/server/services/build-job-builders/build-job-builder.interface.ts
@@ -14,6 +14,7 @@ export type BuildJobBuilderContext = {
     latestRemoteGitHash: string;
     latestRemoteGitCommitMessage: string;
     queuedAt: string;
+    maxParallelBuilds: number;
     nodeSelector?: Record<string, string>;
     resources?: V1ResourceRequirements;
     gitSshPrivateKeySecretName?: string;

--- a/src/server/services/build-job-builders/dockerfile-build-job-builder.service.ts
+++ b/src/server/services/build-job-builders/dockerfile-build-job-builder.service.ts
@@ -70,7 +70,7 @@ class DockerfileBuildJobBuilder implements BuildJobBuilder {
                         hostUsers: false,
                         serviceAccountName: 'qs-build-watcher',
                         initContainers: [
-                            buildQueueInitContainer.getInitContainer(ctx.buildName, ctx.queuedAt),
+                            buildQueueInitContainer.getInitContainer(ctx.buildName, ctx.queuedAt, ctx.maxParallelBuilds),
                             buildGitInitContainerService.getInitContainer(ctx),
                         ],
                         ...(ctx.nodeSelector ? { nodeSelector: ctx.nodeSelector } : {}),

--- a/src/server/services/build-job-builders/dockerfile-build-job-builder.service.unit.spec.ts
+++ b/src/server/services/build-job-builders/dockerfile-build-job-builder.service.unit.spec.ts
@@ -18,6 +18,7 @@ describe('DockerfileBuildJobBuilder', () => {
             latestRemoteGitHash: 'abc123',
             latestRemoteGitCommitMessage: 'feat: test',
             queuedAt: '123',
+            maxParallelBuilds: 2,
         });
 
         expect(job.metadata?.annotations?.['qs-build-method']).toBe('DOCKERFILE');
@@ -26,6 +27,8 @@ describe('DockerfileBuildJobBuilder', () => {
             'build-queue-init',
             'build-git-init',
         ]);
+        const queueInitContainer = job.spec?.template?.spec?.initContainers?.find((container) => container.name === 'build-queue-init')!;
+        expect(queueInitContainer.env?.find((entry) => entry.name === 'MAX_PARALLEL_BUILDS')?.value).toBe('2');
         expect(job.spec?.template?.spec?.volumes).toEqual([
             expect.objectContaining({
                 name: 'build-workspace',
@@ -65,6 +68,7 @@ describe('DockerfileBuildJobBuilder', () => {
             latestRemoteGitHash: 'abc123',
             latestRemoteGitCommitMessage: 'feat: test',
             queuedAt: '123',
+            maxParallelBuilds: 2,
             gitSshPrivateKeySecretName: 'git-ssh-build-1',
         });
 

--- a/src/server/services/build-job-builders/railpack-build-job-builder.service.ts
+++ b/src/server/services/build-job-builders/railpack-build-job-builder.service.ts
@@ -72,7 +72,7 @@ class RailpackBuildJobBuilder implements BuildJobBuilder {
                         hostUsers: false,
                         serviceAccountName: 'qs-build-watcher',
                         initContainers: [
-                            buildQueueInitContainer.getInitContainer(ctx.buildName, ctx.queuedAt),
+                            buildQueueInitContainer.getInitContainer(ctx.buildName, ctx.queuedAt, ctx.maxParallelBuilds),
                             buildGitInitContainerService.getInitContainer(ctx),
                             this.getPreparedRailpackInitContainer(),
                         ],

--- a/src/server/services/build-job-builders/railpack-build-job-builder.service.unit.spec.ts
+++ b/src/server/services/build-job-builders/railpack-build-job-builder.service.unit.spec.ts
@@ -17,6 +17,7 @@ describe('RailpackBuildJobBuilder', () => {
             latestRemoteGitHash: 'abc123',
             latestRemoteGitCommitMessage: 'feat: test',
             queuedAt: '123',
+            maxParallelBuilds: 2,
         });
 
         const initContainers = job.spec?.template?.spec?.initContainers ?? [];

--- a/src/server/services/build.service.builders.unit.spec.ts
+++ b/src/server/services/build.service.builders.unit.spec.ts
@@ -33,10 +33,11 @@ vi.mock('@/server/services/param.service', () => ({
         BUILD_MEMORY_RESERVATION: 'BUILD_MEMORY_RESERVATION',
         BUILD_CPU_LIMIT: 'BUILD_CPU_LIMIT',
         BUILD_CPU_RESERVATION: 'BUILD_CPU_RESERVATION',
+        MAX_PARALLEL_BUILDS: 'MAX_PARALLEL_BUILDS',
     },
     default: {
         getString: vi.fn(async (key: string) => key === 'REGISTRY_SOTRAGE_LOCATION' ? 'registry-path' : undefined),
-        getNumber: vi.fn().mockResolvedValue(undefined),
+        getNumber: vi.fn(async (name: string) => name === 'MAX_PARALLEL_BUILDS' ? 1 : undefined),
     },
 }));
 vi.mock('@/server/services/cluster.service', () => ({
@@ -71,6 +72,7 @@ import dockerfileBuildJobBuilder from '@/server/services/build-job-builders/dock
 import railpackBuildJobBuilder from '@/server/services/build-job-builders/railpack-build-job-builder.service';
 import appGitSshKeyService from '@/server/services/app-git-ssh-key.service';
 import agentGitSshKeyService from '@/server/services/agent-git-ssh-key.service';
+import paramService from '@/server/services/param.service';
 
 describe('BuildService.buildApp builder selection', () => {
     const dockerfileCheckSpy = vi.fn();
@@ -152,5 +154,23 @@ describe('BuildService.buildApp builder selection', () => {
             gitSshPrivateKeySecretName: 'agent-git-ssh-build-secret',
         }));
         expect(railpackBuildJobBuilder.buildJobDefinition).not.toHaveBeenCalled();
+    });
+
+    it('passes the configured max parallel builds to the selected builder', async () => {
+        vi.mocked(paramService.getNumber).mockImplementation(async (name: string) => name === 'MAX_PARALLEL_BUILDS' ? 3 : undefined);
+
+        await buildService.buildApp('deployment-1', {
+            id: 'app-1',
+            projectId: 'project-1',
+            sourceType: 'GIT',
+            buildMethod: 'DOCKERFILE',
+            gitUrl: 'https://github.com/example/repo.git',
+            gitBranch: 'main',
+            dockerfilePath: './Dockerfile',
+        } as any);
+
+        expect(dockerfileBuildJobBuilder.buildJobDefinition).toHaveBeenCalledWith(expect.objectContaining({
+            maxParallelBuilds: 3,
+        }));
     });
 });

--- a/src/server/services/build.service.ts
+++ b/src/server/services/build.service.ts
@@ -104,6 +104,7 @@ class BuildService {
 
         const queuedAt = Date.now().toString();
         const schedulingConfig = await this.getBuildSchedulingConfig(deploymentId);
+        const maxParallelBuilds = await this.getMaxParallelBuilds(deploymentId);
         const gitSshPrivateKeySecretName = workload.sourceType === 'GIT_SSH'
             ? await this.createTemporaryGitSshBuildSecret(workloadType, workload.id, buildName)
             : undefined;
@@ -118,6 +119,7 @@ class BuildService {
                 latestRemoteGitCommitMessage,
                 queuedAt,
                 ...schedulingConfig,
+                maxParallelBuilds,
                 gitSshPrivateKeySecretName,
             });
 
@@ -136,6 +138,13 @@ class BuildService {
             return 'DOCKERFILE';
         }
         return workload.buildMethod === 'DOCKERFILE' ? 'DOCKERFILE' : 'RAILPACK';
+    }
+
+    private async getMaxParallelBuilds(deploymentId: string): Promise<number> {
+        const configured = await paramService.getNumber(ParamService.MAX_PARALLEL_BUILDS, Constants.DEFAULT_MAX_PARALLEL_BUILDS) ?? Constants.DEFAULT_MAX_PARALLEL_BUILDS;
+        const maxParallelBuilds = Math.min(Constants.MAX_PARALLEL_BUILDS_LIMIT, Math.max(Constants.DEFAULT_MAX_PARALLEL_BUILDS, Math.floor(configured)));
+        await dlog(deploymentId, `Max parallel builds: ${maxParallelBuilds}`);
+        return maxParallelBuilds;
     }
 
     private getBuilder(buildMethod: AppBuildMethod): BuildJobBuilder {

--- a/src/server/services/param.service.ts
+++ b/src/server/services/param.service.ts
@@ -84,7 +84,7 @@ export class ParamService {
         })(name);
     }
 
-    async getBoolean(name: string, defaultValue?: boolean) {
+    async getBoolean(name: string, defaultValue?: boolean, revalidateParam = true) {
         const param = await this.getOrUndefined(name);
         if (param) {
             return param.value === 'true';
@@ -93,13 +93,13 @@ export class ParamService {
             await this.save({
                 name,
                 value: defaultValue.toString()
-            });
+            }, revalidateParam);
             return defaultValue;
         }
         return undefined;
     }
 
-    async getString(name: string, defaultValue?: string) {
+    async getString(name: string, defaultValue?: string, revalidateParam = true) {
         const param = await this.getOrUndefined(name);
         if (param) {
             return param.value;
@@ -108,13 +108,13 @@ export class ParamService {
             await this.save({
                 name,
                 value: defaultValue
-            });
+            }, revalidateParam);
             return defaultValue;
         }
         return undefined;
     }
 
-    async getNumber(name: string, defaultValue?: number) {
+    async getNumber(name: string, defaultValue?: number, revalidateParam = true) {
         const param = await this.getOrUndefined(name);
         if (param) {
             return Number(param.value);
@@ -123,7 +123,7 @@ export class ParamService {
             await this.save({
                 name,
                 value: defaultValue.toString()
-            });
+            }, revalidateParam);
             return defaultValue;
         }
         return undefined;
@@ -170,7 +170,7 @@ export class ParamService {
     }
 
 
-    async save(item: Prisma.ParameterUncheckedCreateInput | Prisma.ParameterUncheckedUpdateInput) {
+    async save(item: Prisma.ParameterUncheckedCreateInput | Prisma.ParameterUncheckedUpdateInput, revalidateParam = true) {
         let savedItem: Parameter;
         try {
             savedItem = await dataAccess.client.parameter.upsert({
@@ -183,7 +183,9 @@ export class ParamService {
                 } as Prisma.ParameterUncheckedUpdateInput
             });
         } finally {
-            revalidateTag(Tags.parameter());
+            if (revalidateParam) {
+                revalidateTag(Tags.parameter());
+            }
         }
         return savedItem;
     }

--- a/src/server/services/param.service.ts
+++ b/src/server/services/param.service.ts
@@ -20,6 +20,7 @@ export class ParamService {
     static readonly BUILD_CPU_LIMIT = 'buildCpuLimit';
     static readonly BUILD_CPU_RESERVATION = 'buildCpuReservation';
     static readonly BUILD_NODE = 'buildNode';
+    static readonly MAX_PARALLEL_BUILDS = 'maxParallelBuilds';
     static readonly QS_INSTANCE_ID = 'qsInstanceId';
     static readonly API_OPEN_API_SPEC_ENABLED = 'apiOpenApiSpecEnabled';
     static readonly AGENT_JWT_SECRET = 'agentJwtSecret';

--- a/src/server/services/standalone-services/build-pod-log-watch.service.ts
+++ b/src/server/services/standalone-services/build-pod-log-watch.service.ts
@@ -84,10 +84,7 @@ class BuildPodLogWatchService {
         const containerStatuses = pod.status?.containerStatuses ?? [];
 
         return [
-            ...(pod.spec?.initContainers ?? []).filter((container) => {
-                // th elogs of the container wich waits for the build to start does not contain useful information, so we skip it.
-                return !container.name.toLowerCase().includes(Constants.QS_BUILD_INIT_CONTAINER_NAME.toLowerCase());
-            }).map((container) => ({
+            ...(pod.spec?.initContainers ?? []).map((container) => ({
                 name: container.name!,
                 status: initStatuses.find((status) => status.name === container.name),
             })),

--- a/src/server/services/standalone-services/build-pod-log-watch.service.unit.spec.ts
+++ b/src/server/services/standalone-services/build-pod-log-watch.service.unit.spec.ts
@@ -106,4 +106,41 @@ describe('BuildPodLogWatchService', () => {
         endStream?.();
         await flushPromises();
     });
+
+    it('streams queue init-container logs', async () => {
+        const pod = {
+            metadata: {
+                uid: 'pod-uid-queue',
+                name: 'build-pod-queue',
+                annotations: {
+                    'qs-deplyoment-id': 'deployment-queue',
+                },
+            },
+            spec: {
+                initContainers: [{ name: 'build-queue-init' }],
+                containers: [],
+            },
+            status: {
+                initContainerStatuses: [
+                    { name: 'build-queue-init', state: { terminated: { exitCode: 0 } } },
+                ],
+            },
+        };
+
+        vi.mocked(k3s.log.log).mockImplementation(async (_ns, _podName, _containerName, logStream) => {
+            (logStream as stream.PassThrough).end();
+            return { abort: vi.fn() } as any;
+        });
+
+        await (buildPodLogWatchService as any).captureLogsForPod(pod);
+        await flushPromises();
+
+        expect(vi.mocked(k3s.log.log)).toHaveBeenCalledWith(
+            'qs-build',
+            'build-pod-queue',
+            'build-queue-init',
+            expect.any(stream.PassThrough),
+            expect.objectContaining({ follow: false }),
+        );
+    });
 });

--- a/src/shared/model/build-settings.model.ts
+++ b/src/shared/model/build-settings.model.ts
@@ -1,7 +1,26 @@
 import { stringToOptionalNumber } from "@/shared/utils/zod.utils";
 import { z } from "zod";
+import { Constants } from "@/shared/utils/constants";
+
+const stringToParallelBuilds = z.preprocess((val) => {
+    if (val === null || val === undefined || val === '') {
+        return undefined;
+    }
+    if (typeof val === 'string') {
+        const parsed = parseInt(val, 10);
+        return Number.isNaN(parsed) ? undefined : parsed;
+    }
+    return val;
+}, z.number().int({
+    message: 'Max parallel builds must be a whole number.',
+}).min(Constants.DEFAULT_MAX_PARALLEL_BUILDS, {
+    message: `Max parallel builds must be between ${Constants.DEFAULT_MAX_PARALLEL_BUILDS} and ${Constants.MAX_PARALLEL_BUILDS_LIMIT}.`,
+}).max(Constants.MAX_PARALLEL_BUILDS_LIMIT, {
+    message: `Max parallel builds must be between ${Constants.DEFAULT_MAX_PARALLEL_BUILDS} and ${Constants.MAX_PARALLEL_BUILDS_LIMIT}.`,
+}));
 
 export const buildSettingsZodModel = z.object({
+    maxParallelBuilds: stringToParallelBuilds,
     memoryReservation: stringToOptionalNumber,
     memoryLimit: stringToOptionalNumber,
     cpuReservation: stringToOptionalNumber,

--- a/src/shared/utils/constants.ts
+++ b/src/shared/utils/constants.ts
@@ -36,6 +36,8 @@ export class Constants {
     static readonly TOLERATION_FOR_EXECUTED_CRON_BACKUPS_MS = 60 * 60 * 1000; // 60 minutes;
     static readonly BUILD_NODE_K3S_NATIVE_VALUE = 'k3s-native';
     static readonly BUILD_AUTO_NODE_VALUE = '__auto__';
+    static readonly DEFAULT_MAX_PARALLEL_BUILDS = 1;
+    static readonly MAX_PARALLEL_BUILDS_LIMIT = 20;
     static readonly QS_BUILD_INIT_CONTAINER_NAME = 'build-queue-init';
     static readonly QS_AGENT_ROUTER_NAMESPACE = Constants.QS_NAMESPACE;
     static readonly QS_AUTH_PROXY_IMAGE = 'quickstack/auth-proxy:canary';


### PR DESCRIPTION
## What

Implements #99 (builds part). Adds a **Max Parallel Builds** setting (1–20, default **1**) under *Settings → QuickStack Server → Builds*.

## How

- New global parameter `maxParallelBuilds` (default `1`), persisted via the existing build settings action, Zod-clamped to 1–20.
- The queue keeps its current self-checking init-container approach (`build-queue-init` polls the jobs in `registry-and-build`), but the slot rule changes from *only the single oldest pending build may start* to *the N oldest pending builds may start* (**count-older** logic, deterministic name tiebreak for equal timestamps).
- Limit is read when a build job is created and embedded into that job (per-job env `MAX_PARALLEL_BUILDS`). Running/waiting builds finish with the limit they were scheduled with; new builds pick up a changed value. No RBAC or ConfigMap changes needed.

## Notes / behavior

- Per-workload guard stays: still max 1 active build per app/agent; N applies globally across workloads.
- Deployments triggered on build success can now start closer together when N > 1 (previously implicitly serialized by the build queue).

## Tests

- New unit tests for init-container count-older logic, default, and clamping.
- Builder + build-service tests updated/added for passing the limit through.

Closes: build portion of #99