### PR TITLE
feat: add rollback support for git deployments

### DIFF
--- a/src/app/project/app/[appId]/overview/actions.ts
+++ b/src/app/project/app/[appId]/overview/actions.ts
@@ -24,6 +24,13 @@ export const deleteBuild = async (buildName: string) =>
         return new SuccessActionResult(undefined, 'Successfully stopped and deleted build.');
     });
 
+export const rollbackToDeployment = async (appId: string, deploymentId: string) =>
+    simpleAction(async () => {
+        await isAuthorizedWriteForApp(appId);
+        await appService.rollbackToDeployment(appId, deploymentId);
+        return new SuccessActionResult(undefined, 'Successfully started rollback.');
+    });
+
 export const getPodsForApp = async (appId: string) =>
     simpleAction(async () => {
         await isAuthorizedReadForApp(appId);

--- a/src/app/project/app/[appId]/overview/deployments.tsx
+++ b/src/app/project/app/[appId]/overview/deployments.tsx
@@ -13,6 +13,10 @@ import DeploymentStatusBadge from "./deployment-status-badge";
 import { BuildLogsDialog } from "./build-logs-overlay";
 import ShortCommitHash from "@/components/custom/short-commit-hash";
 import { RolePermissionEnum } from "@/shared/model/role-extended.model.ts";
+import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from "@/components/ui/dropdown-menu";
+import { RotateCcw } from "lucide-react";
+import { DotsVerticalIcon } from "@radix-ui/react-icons";
+import { GitHashUtils } from "@/shared/utils/git-hash.utils";
 
 export default function BuildsTab({
     app,
@@ -58,7 +62,7 @@ export default function BuildsTab({
     const rollbackClick = async (item: DeploymentInfoModel) => {
         const confirm = await openDialog({
             title: "Rollback Deployment",
-            description: `Roll back to git commit ${item.gitCommit?.slice(0, 7)}? The App will be redeployed with the code from this commit.`,
+            description: `Roll back to git commit ${GitHashUtils.shortGitHash(item.gitCommit)}? The App will be redeployed with the code from this commit.`,
             okButton: "Rollback"
         });
         if (confirm) {
@@ -115,8 +119,22 @@ export default function BuildsTab({
                                 <div className="flex gap-4">
                                     <div className="flex-1"></div>
                                     {item.deploymentId && <Button variant="secondary" onClick={() => setSelectedDeploymentForLogs(item)}>Show Logs</Button>}
-                                    {role === RolePermissionEnum.READWRITE && item.gitCommit && <Button variant="outline" onClick={() => rollbackClick(item)}>Rollback</Button>}
                                     {role === RolePermissionEnum.READWRITE && item.buildJobName && item.status === 'BUILDING' && <Button variant="destructive" onClick={() => deleteBuildClick(item.buildJobName!)}>Stop Build</Button>}
+                                    {role === RolePermissionEnum.READWRITE && item.gitCommit && (
+                                        <DropdownMenu>
+                                            <DropdownMenuTrigger asChild>
+                                                <Button variant="outline">
+                                                    <DotsVerticalIcon></DotsVerticalIcon>
+                                                </Button>
+                                            </DropdownMenuTrigger>
+                                            <DropdownMenuContent align="end">
+                                                <DropdownMenuItem onSelect={() => rollbackClick(item)}>
+                                                    <RotateCcw />
+                                                    Rollback to this deployment
+                                                </DropdownMenuItem>
+                                            </DropdownMenuContent>
+                                        </DropdownMenu>
+                                    )}
                                 </div>
                             </>
                         }}

--- a/src/app/project/app/[appId]/overview/deployments.tsx
+++ b/src/app/project/app/[appId]/overview/deployments.tsx
@@ -3,7 +3,7 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/com
 import { formatDateTime } from "@/frontend/utils/format.utils";
 import { AppExtendedModel } from "@/shared/model/app-extended.model";
 import { useCallback, useEffect, useState } from "react";
-import { deleteBuild, getDeploymentsAndBuildsForApp } from "./actions";
+import { deleteBuild, getDeploymentsAndBuildsForApp, rollbackToDeployment } from "./actions";
 import FullLoadingSpinner from "@/components/ui/full-loading-spinnter";
 import { Button } from "@/components/ui/button";
 import { useConfirmDialog } from "@/frontend/states/zustand.states";
@@ -55,6 +55,18 @@ export default function BuildsTab({
         }
     }
 
+    const rollbackClick = async (item: DeploymentInfoModel) => {
+        const confirm = await openDialog({
+            title: "Rollback Deployment",
+            description: `Roll back to git commit ${item.gitCommit?.slice(0, 7)}? The App will be redeployed with the code from this commit.`,
+            okButton: "Rollback"
+        });
+        if (confirm) {
+            await Toast.fromAction(() => rollbackToDeployment(app.id, item.deploymentId));
+            await updateBuilds();
+        }
+    }
+
     useEffect(() => {
         if (app.sourceType === 'container') {
             return;
@@ -81,7 +93,12 @@ export default function BuildsTab({
                         ['replicasetName', 'Deployment Name', false],
                         ['buildJobName', 'Build Job Name', false],
                         ['deploymentId', 'Deployment Id', false],
-                        ['status', 'Status', true, (item) => <DeploymentStatusBadge>{item.status}</DeploymentStatusBadge>],
+                        ['status', 'Status', true, (item) => (
+                            <div className="flex items-center gap-2">
+                                <DeploymentStatusBadge>{item.status}</DeploymentStatusBadge>
+                                {item.isRollback && <span className="px-2 py-1 rounded-lg text-sm font-semibold bg-purple-100 text-purple-800">Rollback</span>}
+                            </div>
+                        )],
                         ['buildMethod', 'Build Method', true, (item) => (
                             <span className="text-muted-foreground text-sm">
                                 {item.buildMethod ? (item.buildMethod === 'DOCKERFILE' ? 'Dockerfile' : 'Railpack') : '—'}
@@ -98,6 +115,7 @@ export default function BuildsTab({
                                 <div className="flex gap-4">
                                     <div className="flex-1"></div>
                                     {item.deploymentId && <Button variant="secondary" onClick={() => setSelectedDeploymentForLogs(item)}>Show Logs</Button>}
+                                    {role === RolePermissionEnum.READWRITE && item.gitCommit && <Button variant="outline" onClick={() => rollbackClick(item)}>Rollback</Button>}
                                     {role === RolePermissionEnum.READWRITE && item.buildJobName && item.status === 'BUILDING' && <Button variant="destructive" onClick={() => deleteBuildClick(item.buildJobName!)}>Stop Build</Button>}
                                 </div>
                             </>

--- a/src/app/project/app/[appId]/overview/deployments.tsx
+++ b/src/app/project/app/[appId]/overview/deployments.tsx
@@ -115,12 +115,17 @@ export default function BuildsTab({
                         data={appBuilds}
                         hideSearchBar={true}
                         actionCol={(item) => {
+                            const isRollbackTarget = role === RolePermissionEnum.READWRITE
+                                && !!item.replicasetName
+                                && !!item.gitCommit
+                                && item.status !== 'DEPLOYING'
+                                && item.status !== 'DEPLOYED';
                             return <>
                                 <div className="flex gap-4">
                                     <div className="flex-1"></div>
                                     {item.deploymentId && <Button variant="secondary" onClick={() => setSelectedDeploymentForLogs(item)}>Show Logs</Button>}
                                     {role === RolePermissionEnum.READWRITE && item.buildJobName && item.status === 'BUILDING' && <Button variant="destructive" onClick={() => deleteBuildClick(item.buildJobName!)}>Stop Build</Button>}
-                                    {role === RolePermissionEnum.READWRITE && item.status !== 'DEPLOYING' && item.status !== 'DEPLOYED' && item.gitCommit && (
+                                    {isRollbackTarget && (
                                         <DropdownMenu>
                                             <DropdownMenuTrigger asChild>
                                                 <Button variant="outline">

--- a/src/app/project/app/[appId]/overview/deployments.tsx
+++ b/src/app/project/app/[appId]/overview/deployments.tsx
@@ -120,7 +120,7 @@ export default function BuildsTab({
                                     <div className="flex-1"></div>
                                     {item.deploymentId && <Button variant="secondary" onClick={() => setSelectedDeploymentForLogs(item)}>Show Logs</Button>}
                                     {role === RolePermissionEnum.READWRITE && item.buildJobName && item.status === 'BUILDING' && <Button variant="destructive" onClick={() => deleteBuildClick(item.buildJobName!)}>Stop Build</Button>}
-                                    {role === RolePermissionEnum.READWRITE && item.gitCommit && (
+                                    {role === RolePermissionEnum.READWRITE && item.status !== 'DEPLOYING' && item.status !== 'DEPLOYED' && item.gitCommit && (
                                         <DropdownMenu>
                                             <DropdownMenuTrigger asChild>
                                                 <Button variant="outline">

--- a/src/components/custom/short-commit-hash.tsx
+++ b/src/components/custom/short-commit-hash.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
 import { Code } from './code';
+import { GitHashUtils } from '@/shared/utils/git-hash.utils';
 
 export default function ShortCommitHash({ children }: { children?: string }) {
-    const shortHash = children ? children.slice(0, 7) : '';
+    const shortHash = GitHashUtils.shortGitHash(children) ?? '';
     if (!shortHash) {
         return <></>;
     }
     return (<Code copieableValue={children}>{shortHash}</Code>);
 };
-

--- a/src/server/services/app.service.ts
+++ b/src/server/services/app.service.ts
@@ -7,6 +7,7 @@ import { ServiceException } from "@/shared/model/service.exception.model";
 import { KubeObjectNameUtils } from "../utils/kube-object-name.utils";
 import deploymentService from "./deployment.service";
 import buildService from "./build.service";
+import registryService from "./registry.service";
 import ingressService from "./ingress.service";
 import pvcService from "./pvc.service";
 import svcService from "./svc.service";
@@ -16,6 +17,7 @@ import networkPolicyService from "./network-policy.service";
 import appNetworkPolicyService from "./app-network-policy.service";
 import { AppBasicAuthModel, AppDomainModel, AppFileMountModel, AppModel, AppNodePortModel, AppPortModel, AppVolumeModel } from "@/shared/model/generated-zod";
 import { z } from "zod";
+import { shortGitHash } from "@/shared/utils/git-hash.utils";
 
 class AppService {
 
@@ -49,6 +51,49 @@ class AppService {
             } else {
                 // only deploy
                 await deploymentService.createDeployment(deploymentId, app);
+            }
+        });
+        return deploymentId;
+    }
+
+    async rollbackToDeployment(appId: string, targetDeploymentId: string) {
+        const deploymentId = crypto.randomUUID();
+        await deploymentLogService.catchErrosAndLog(deploymentId, async () => {
+            const app = await this.getExtendedById(appId);
+
+            const target = await deploymentService.getDeploymentHistoryEntryById(app.projectId, appId, targetDeploymentId);
+            if (!target) {
+                throw new ServiceException('The selected deployment could not be found.');
+            }
+
+            const gitCommit = target.gitCommit;
+            if (!gitCommit) {
+                throw new ServiceException('The selected deployment has no git commit to roll back to.');
+            }
+
+            await dlog(deploymentId, `
+----------------------------------------------
+ Rollback:     ${deploymentId}
+ App:          ${app.id}
+ Project:      ${app.projectId}
+ Target:       ${gitCommit}
+----------------------------------------------`, false);
+
+            const tag = shortGitHash(gitCommit);
+            if (tag && await registryService.doesImageExist(app.id, tag)) {
+                await dlog(deploymentId, `Image for commit ${gitCommit} already exists in the registry, redeploying it.`);
+                await deploymentService.createDeployment(
+                    deploymentId,
+                    app,
+                    undefined,
+                    gitCommit,
+                    target.gitCommitMessage,
+                    target.buildMethod,
+                    true,
+                );
+            } else {
+                await dlog(deploymentId, `Image for commit ${gitCommit} not found in the registry, starting a new build.`);
+                await buildService.buildAppAtCommit(deploymentId, app, gitCommit, target.gitCommitMessage);
             }
         });
         return deploymentId;

--- a/src/server/services/app.service.ts
+++ b/src/server/services/app.service.ts
@@ -93,7 +93,7 @@ class AppService {
                 );
             } else {
                 await dlog(deploymentId, `Image for commit ${gitCommit} not found in the registry, starting a new build.`);
-                await buildService.buildAppAtCommit(deploymentId, app, gitCommit, target.gitCommitMessage);
+                await buildService.buildAppAtCommit(deploymentId, app, gitCommit, target.gitCommitMessage, true);
             }
         });
         return deploymentId;

--- a/src/server/services/app.service.ts
+++ b/src/server/services/app.service.ts
@@ -17,7 +17,7 @@ import networkPolicyService from "./network-policy.service";
 import appNetworkPolicyService from "./app-network-policy.service";
 import { AppBasicAuthModel, AppDomainModel, AppFileMountModel, AppModel, AppNodePortModel, AppPortModel, AppVolumeModel } from "@/shared/model/generated-zod";
 import { z } from "zod";
-import { shortGitHash } from "@/shared/utils/git-hash.utils";
+import { GitHashUtils } from "@/shared/utils/git-hash.utils";
 
 class AppService {
 
@@ -79,7 +79,7 @@ class AppService {
  Target:       ${gitCommit}
 ----------------------------------------------`, false);
 
-            const tag = shortGitHash(gitCommit);
+            const tag = GitHashUtils.shortGitHash(gitCommit);
             if (tag && await registryService.doesImageExist(app.id, tag)) {
                 await dlog(deploymentId, `Image for commit ${gitCommit} already exists in the registry, redeploying it.`);
                 await deploymentService.createDeployment(

--- a/src/server/services/app.service.ts
+++ b/src/server/services/app.service.ts
@@ -38,14 +38,12 @@ class AppService {
                 const [buildJobName, gitCommitHash, gitCommitMessage, shouldDeployImmediately] = await buildService.buildApp(deploymentId, app, forceBuild);
                 if (shouldDeployImmediately) {
                     dlog(deploymentId, `Starting deployment with output from build "${buildJobName}"`);
-                    await deploymentService.createDeployment(
-                        deploymentId,
-                        app,
+                    await deploymentService.createDeployment(deploymentId, app, {
                         buildJobName,
                         gitCommitHash,
                         gitCommitMessage,
-                        app.buildMethod === 'DOCKERFILE' ? 'DOCKERFILE' : 'RAILPACK',
-                    );
+                        buildMethod: app.buildMethod === 'DOCKERFILE' ? 'DOCKERFILE' : 'RAILPACK',
+                    });
                 }
                 // Otherwise the build-watch service will trigger the deployment once the build job completes
             } else {
@@ -82,18 +80,19 @@ class AppService {
             const tag = GitHashUtils.shortGitHash(gitCommit);
             if (tag && await registryService.doesImageExist(app.id, tag)) {
                 await dlog(deploymentId, `Image for commit ${gitCommit} already exists in the registry, redeploying it.`);
-                await deploymentService.createDeployment(
-                    deploymentId,
-                    app,
-                    undefined,
-                    gitCommit,
-                    target.gitCommitMessage,
-                    target.buildMethod,
-                    true,
-                );
+                await deploymentService.createDeployment(deploymentId, app, {
+                    gitCommitHash: gitCommit,
+                    gitCommitMessage: target.gitCommitMessage,
+                    buildMethod: target.buildMethod,
+                    isRollback: true,
+                });
             } else {
                 await dlog(deploymentId, `Image for commit ${gitCommit} not found in the registry, starting a new build.`);
-                await buildService.buildAppAtCommit(deploymentId, app, gitCommit, target.gitCommitMessage, true);
+                await buildService.buildAppAtCommit(deploymentId, app, {
+                    gitCommitHash: gitCommit,
+                    gitCommitMessage: target.gitCommitMessage,
+                    isRollback: true,
+                });
             }
         });
         return deploymentId;

--- a/src/server/services/app.service.unit.spec.ts
+++ b/src/server/services/app.service.unit.spec.ts
@@ -26,22 +26,46 @@ vi.mock('@/server/adapter/db.client', () => ({
     },
 }));
 vi.mock('@/server/adapter/kubernetes-api.adapter', () => ({ default: {} }));
-vi.mock('@/server/services/deployment.service', () => ({ default: {} }));
-vi.mock('@/server/services/build.service', () => ({ default: {} }));
+vi.mock('@/server/services/deployment.service', () => ({
+    default: {
+        getDeploymentHistoryEntryById: vi.fn(),
+        createDeployment: vi.fn(),
+    },
+}));
+vi.mock('@/server/services/build.service', () => ({
+    default: {
+        buildApp: vi.fn(),
+        buildAppAtCommit: vi.fn(),
+    },
+}));
+vi.mock('@/server/services/registry.service', () => ({
+    default: {
+        doesImageExist: vi.fn(),
+    },
+}));
 vi.mock('@/server/services/ingress.service', () => ({ default: {} }));
 vi.mock('@/server/services/pvc.service', () => ({ default: {} }));
 vi.mock('@/server/services/svc.service', () => ({ default: {} }));
-vi.mock('@/server/services/deployment-logs.service', () => ({ default: {}, dlog: vi.fn() }));
+vi.mock('@/server/services/deployment-logs.service', () => ({
+    default: {
+        catchErrosAndLog: vi.fn(async (_id: string, fn: () => Promise<void>) => fn()),
+    },
+    dlog: vi.fn(),
+}));
 vi.mock('@/server/services/network-policy.service', () => ({ default: {} }));
 vi.mock('@/server/services/app-network-policy.service', () => ({ default: { replaceConfiguration: vi.fn() } }));
 
 import appService from './app.service';
 import { AppExtendedModel } from '@/shared/model/app-extended.model';
 import dataAccess from '@/server/adapter/db.client';
+import deploymentService from './deployment.service';
+import buildService from './build.service';
+import registryService from './registry.service';
 
 describe('app.service', () => {
     beforeEach(() => {
         vi.restoreAllMocks();
+        vi.clearAllMocks();
     });
 
     it('persists App Node Ports when saving an extended App', async () => {
@@ -125,6 +149,71 @@ describe('app.service', () => {
         })).rejects.toThrow('App domain has ID, but existing item for app was not found.');
 
         expect(dataAccess.client.appDomain.update).not.toHaveBeenCalled();
+    });
+
+    it('redeploys an existing commit image when rolling back to a deployment with a cached image', async () => {
+        vi.spyOn(appService, 'getExtendedById').mockResolvedValue(createApp({ sourceType: 'GIT' }) as never);
+        vi.mocked(deploymentService.getDeploymentHistoryEntryById).mockResolvedValue({
+            deploymentId: 'target-1',
+            createdAt: new Date(),
+            status: 'DEPLOYED',
+            gitCommit: 'abcdef1234567890',
+            gitCommitMessage: 'old commit',
+            buildMethod: 'RAILPACK',
+        } as never);
+        vi.mocked(registryService.doesImageExist).mockResolvedValue(true);
+
+        await appService.rollbackToDeployment('demo-app', 'target-1');
+
+        expect(deploymentService.createDeployment).toHaveBeenCalledWith(
+            expect.any(String),
+            expect.objectContaining({ id: 'demo-app' }),
+            undefined,
+            'abcdef1234567890',
+            'old commit',
+            'RAILPACK',
+            true,
+        );
+        expect(buildService.buildAppAtCommit).not.toHaveBeenCalled();
+    });
+
+    it('builds the commit when rolling back to a deployment whose image is missing', async () => {
+        vi.spyOn(appService, 'getExtendedById').mockResolvedValue(createApp({ sourceType: 'GIT' }) as never);
+        vi.mocked(deploymentService.getDeploymentHistoryEntryById).mockResolvedValue({
+            deploymentId: 'target-1',
+            createdAt: new Date(),
+            status: 'DEPLOYED',
+            gitCommit: 'abcdef1234567890',
+            gitCommitMessage: 'old commit',
+            buildMethod: 'RAILPACK',
+        } as never);
+        vi.mocked(registryService.doesImageExist).mockResolvedValue(false);
+
+        await appService.rollbackToDeployment('demo-app', 'target-1');
+
+        expect(buildService.buildAppAtCommit).toHaveBeenCalledWith(
+            expect.any(String),
+            expect.objectContaining({ id: 'demo-app' }),
+            'abcdef1234567890',
+            'old commit',
+        );
+        expect(deploymentService.createDeployment).not.toHaveBeenCalled();
+    });
+
+    it('rejects a rollback to a deployment without a git commit', async () => {
+        vi.spyOn(appService, 'getExtendedById').mockResolvedValue(createApp({ sourceType: 'GIT' }) as never);
+        vi.mocked(deploymentService.getDeploymentHistoryEntryById).mockResolvedValue({
+            deploymentId: 'target-1',
+            createdAt: new Date(),
+            status: 'DEPLOYED',
+        } as never);
+
+        await expect(appService.rollbackToDeployment('demo-app', 'target-1'))
+            .rejects.toThrow('The selected deployment has no git commit to roll back to.');
+
+        expect(registryService.doesImageExist).not.toHaveBeenCalled();
+        expect(buildService.buildAppAtCommit).not.toHaveBeenCalled();
+        expect(deploymentService.createDeployment).not.toHaveBeenCalled();
     });
 });
 

--- a/src/server/services/app.service.unit.spec.ts
+++ b/src/server/services/app.service.unit.spec.ts
@@ -168,11 +168,12 @@ describe('app.service', () => {
         expect(deploymentService.createDeployment).toHaveBeenCalledWith(
             expect.any(String),
             expect.objectContaining({ id: 'demo-app' }),
-            undefined,
-            'abcdef1234567890',
-            'old commit',
-            'RAILPACK',
-            true,
+            expect.objectContaining({
+                gitCommitHash: 'abcdef1234567890',
+                gitCommitMessage: 'old commit',
+                buildMethod: 'RAILPACK',
+                isRollback: true,
+            }),
         );
         expect(buildService.buildAppAtCommit).not.toHaveBeenCalled();
     });
@@ -194,9 +195,11 @@ describe('app.service', () => {
         expect(buildService.buildAppAtCommit).toHaveBeenCalledWith(
             expect.any(String),
             expect.objectContaining({ id: 'demo-app' }),
-            'abcdef1234567890',
-            'old commit',
-            true,
+            expect.objectContaining({
+                gitCommitHash: 'abcdef1234567890',
+                gitCommitMessage: 'old commit',
+                isRollback: true,
+            }),
         );
         expect(deploymentService.createDeployment).not.toHaveBeenCalled();
     });

--- a/src/server/services/app.service.unit.spec.ts
+++ b/src/server/services/app.service.unit.spec.ts
@@ -196,6 +196,7 @@ describe('app.service', () => {
             expect.objectContaining({ id: 'demo-app' }),
             'abcdef1234567890',
             'old commit',
+            true,
         );
         expect(deploymentService.createDeployment).not.toHaveBeenCalled();
     });

--- a/src/server/services/build-job-builders/build-job-annotations.utils.ts
+++ b/src/server/services/build-job-builders/build-job-annotations.utils.ts
@@ -1,0 +1,31 @@
+import { Constants } from "@/shared/utils/constants";
+import { AppBuildMethod } from "@/shared/model/app-source-info.model";
+import { BuildJobBuilderContext } from "./build-job-builder.interface";
+
+export class BuildJobAnnotationsUtils {
+    static createBuildJobAnnotations(ctx: BuildJobBuilderContext, buildMethod: AppBuildMethod, includeQueuedAt = false): Record<string, string> {
+        const annotations: Record<string, string> = {
+            [Constants.QS_ANNOTATION_WORKLOAD_TYPE]: ctx.workloadType,
+            [Constants.QS_ANNOTATION_PROJECT_ID]: ctx.workload.projectId,
+            [Constants.QS_ANNOTATION_GIT_COMMIT]: ctx.latestRemoteGitHash,
+            [Constants.QS_ANNOTATION_GIT_COMMIT_MESSAGE]: ctx.latestRemoteGitCommitMessage.substring(0, 200),
+            [Constants.QS_ANNOTATION_DEPLOYMENT_ID]: ctx.deploymentId,
+            [Constants.QS_ANNOTATION_BUILD_METHOD]: buildMethod,
+        };
+        if (ctx.workloadType === 'app') {
+            annotations[Constants.QS_ANNOTATION_APP_ID] = ctx.workload.id;
+        } else {
+            annotations[Constants.QS_ANNOTATION_AGENT_ID] = ctx.workload.id;
+        }
+        if (includeQueuedAt) {
+            annotations[Constants.QS_ANNOTATION_BUILD_QUEUED_AT] = ctx.queuedAt;
+        }
+        if (ctx.isRollback) {
+            annotations[Constants.QS_ANNOTATION_ROLLBACK] = Constants.QS_ANNOTATION_VALUE_TRUE;
+        }
+        if (ctx.gitSshPrivateKeySecretName) {
+            annotations[Constants.QS_ANNOTATION_GIT_SSH_SECRET] = ctx.gitSshPrivateKeySecretName;
+        }
+        return annotations;
+    }
+}

--- a/src/server/services/build-job-builders/build-job-builder.interface.ts
+++ b/src/server/services/build-job-builders/build-job-builder.interface.ts
@@ -18,6 +18,7 @@ export type BuildJobBuilderContext = {
     nodeSelector?: Record<string, string>;
     resources?: V1ResourceRequirements;
     gitSshPrivateKeySecretName?: string;
+    isRollback?: boolean;
 };
 
 export interface BuildJobBuilder {

--- a/src/server/services/build-job-builders/dockerfile-build-job-builder.service.ts
+++ b/src/server/services/build-job-builders/dockerfile-build-job-builder.service.ts
@@ -50,6 +50,7 @@ class DockerfileBuildJobBuilder implements BuildJobBuilder {
                     [Constants.QS_ANNOTATION_DEPLOYMENT_ID]: ctx.deploymentId,
                     [Constants.QS_ANNOTATION_BUILD_QUEUED_AT]: ctx.queuedAt,
                     [Constants.QS_ANNOTATION_BUILD_METHOD]: this.buildMethod,
+                    ...(ctx.isRollback ? { [Constants.QS_ANNOTATION_ROLLBACK]: 'true' } : {}),
                     ...(ctx.gitSshPrivateKeySecretName ? { [Constants.QS_ANNOTATION_GIT_SSH_SECRET]: ctx.gitSshPrivateKeySecretName } : {}),
                 }
             },
@@ -66,6 +67,7 @@ class DockerfileBuildJobBuilder implements BuildJobBuilder {
                             [Constants.QS_ANNOTATION_GIT_COMMIT_MESSAGE]: ctx.latestRemoteGitCommitMessage.substring(0, 200),
                             [Constants.QS_ANNOTATION_DEPLOYMENT_ID]: ctx.deploymentId,
                             [Constants.QS_ANNOTATION_BUILD_METHOD]: this.buildMethod,
+                            ...(ctx.isRollback ? { [Constants.QS_ANNOTATION_ROLLBACK]: 'true' } : {}),
                             ...(ctx.gitSshPrivateKeySecretName ? { [Constants.QS_ANNOTATION_GIT_SSH_SECRET]: ctx.gitSshPrivateKeySecretName } : {}),
                         },
                     },

--- a/src/server/services/build-job-builders/dockerfile-build-job-builder.service.ts
+++ b/src/server/services/build-job-builders/dockerfile-build-job-builder.service.ts
@@ -31,7 +31,7 @@ class DockerfileBuildJobBuilder implements BuildJobBuilder {
             "--opt",
             `filename=${contextPaths.filePath}`,
             "--output",
-            `type=image,name=${imageNames},push=true,registry.insecure=true`
+            `type=image,"name=${imageNames}",push=true,registry.insecure=true`
         ];
 
         return {

--- a/src/server/services/build-job-builders/dockerfile-build-job-builder.service.ts
+++ b/src/server/services/build-job-builders/dockerfile-build-job-builder.service.ts
@@ -1,12 +1,12 @@
 import { V1Job } from "@kubernetes/client-node";
 import { BuildJobBuilder, BuildJobBuilderContext } from "./build-job-builder.interface";
 import { AppBuildMethod } from "@/shared/model/app-source-info.model";
-import { Constants } from "@/shared/utils/constants";
 import buildQueueInitContainer from "./build-init-container.service";
 import buildGitInitContainerService, { BUILD_GIT_SSH_KEY_VOLUME_NAME } from "./build-git-init-container.service";
 import registryService, { BUILD_NAMESPACE } from "../registry.service";
 import { PathUtils } from "@/server/utils/path.utils";
 import { BUILD_SOURCE_PATH, BUILD_WORKSPACE_MOUNT_PATH, BUILD_WORKSPACE_VOLUME_NAME } from "./build-workspace.constants";
+import { BuildJobAnnotationsUtils } from "./build-job-annotations.utils";
 
 const buildkitImage = "moby/buildkit:master";
 
@@ -16,9 +16,7 @@ class DockerfileBuildJobBuilder implements BuildJobBuilder {
     async buildJobDefinition(ctx: BuildJobBuilderContext): Promise<V1Job> {
         const contextPaths = PathUtils.splitPath(ctx.workload.dockerfilePath || './Dockerfile');
         const dockerfileContextPath = this.getDockerfileContextPath(contextPaths.folderPath);
-        const imageNames = ctx.workloadType === 'app'
-            ? registryService.createInternalContainerRegistryImageNamesForApp(ctx.workload.id, ctx.latestRemoteGitHash)
-            : registryService.createInternalContainerRegistryUrlForAppId(ctx.workload.id);
+        const imageNames = registryService.createBuildImageNames(ctx.workload.id, ctx.workloadType, ctx.latestRemoteGitHash, ctx.isRollback);
 
         const buildkitArgs = [
             "build",
@@ -40,36 +38,13 @@ class DockerfileBuildJobBuilder implements BuildJobBuilder {
             metadata: {
                 name: ctx.buildName,
                 namespace: BUILD_NAMESPACE,
-                annotations: {
-                    ...(ctx.workloadType === 'app' ? { [Constants.QS_ANNOTATION_APP_ID]: ctx.workload.id } : {}),
-                    ...(ctx.workloadType === 'agent' ? { [Constants.QS_ANNOTATION_AGENT_ID]: ctx.workload.id } : {}),
-                    [Constants.QS_ANNOTATION_WORKLOAD_TYPE]: ctx.workloadType,
-                    [Constants.QS_ANNOTATION_PROJECT_ID]: ctx.workload.projectId,
-                    [Constants.QS_ANNOTATION_GIT_COMMIT]: ctx.latestRemoteGitHash,
-                    [Constants.QS_ANNOTATION_GIT_COMMIT_MESSAGE]: ctx.latestRemoteGitCommitMessage.substring(0, 200),
-                    [Constants.QS_ANNOTATION_DEPLOYMENT_ID]: ctx.deploymentId,
-                    [Constants.QS_ANNOTATION_BUILD_QUEUED_AT]: ctx.queuedAt,
-                    [Constants.QS_ANNOTATION_BUILD_METHOD]: this.buildMethod,
-                    ...(ctx.isRollback ? { [Constants.QS_ANNOTATION_ROLLBACK]: 'true' } : {}),
-                    ...(ctx.gitSshPrivateKeySecretName ? { [Constants.QS_ANNOTATION_GIT_SSH_SECRET]: ctx.gitSshPrivateKeySecretName } : {}),
-                }
+                annotations: BuildJobAnnotationsUtils.createBuildJobAnnotations(ctx, this.buildMethod, true),
             },
             spec: {
                 ttlSecondsAfterFinished: 86400,
                 template: {
                     metadata: {
-                        annotations: {
-                            ...(ctx.workloadType === 'app' ? { [Constants.QS_ANNOTATION_APP_ID]: ctx.workload.id } : {}),
-                            ...(ctx.workloadType === 'agent' ? { [Constants.QS_ANNOTATION_AGENT_ID]: ctx.workload.id } : {}),
-                            [Constants.QS_ANNOTATION_WORKLOAD_TYPE]: ctx.workloadType,
-                            [Constants.QS_ANNOTATION_PROJECT_ID]: ctx.workload.projectId,
-                            [Constants.QS_ANNOTATION_GIT_COMMIT]: ctx.latestRemoteGitHash,
-                            [Constants.QS_ANNOTATION_GIT_COMMIT_MESSAGE]: ctx.latestRemoteGitCommitMessage.substring(0, 200),
-                            [Constants.QS_ANNOTATION_DEPLOYMENT_ID]: ctx.deploymentId,
-                            [Constants.QS_ANNOTATION_BUILD_METHOD]: this.buildMethod,
-                            ...(ctx.isRollback ? { [Constants.QS_ANNOTATION_ROLLBACK]: 'true' } : {}),
-                            ...(ctx.gitSshPrivateKeySecretName ? { [Constants.QS_ANNOTATION_GIT_SSH_SECRET]: ctx.gitSshPrivateKeySecretName } : {}),
-                        },
+                        annotations: BuildJobAnnotationsUtils.createBuildJobAnnotations(ctx, this.buildMethod),
                     },
                     spec: {
                         hostUsers: false,

--- a/src/server/services/build-job-builders/dockerfile-build-job-builder.service.ts
+++ b/src/server/services/build-job-builders/dockerfile-build-job-builder.service.ts
@@ -16,6 +16,9 @@ class DockerfileBuildJobBuilder implements BuildJobBuilder {
     async buildJobDefinition(ctx: BuildJobBuilderContext): Promise<V1Job> {
         const contextPaths = PathUtils.splitPath(ctx.workload.dockerfilePath || './Dockerfile');
         const dockerfileContextPath = this.getDockerfileContextPath(contextPaths.folderPath);
+        const imageNames = ctx.workloadType === 'app'
+            ? registryService.createInternalContainerRegistryImageNamesForApp(ctx.workload.id, ctx.latestRemoteGitHash)
+            : registryService.createInternalContainerRegistryUrlForAppId(ctx.workload.id);
 
         const buildkitArgs = [
             "build",
@@ -28,7 +31,7 @@ class DockerfileBuildJobBuilder implements BuildJobBuilder {
             "--opt",
             `filename=${contextPaths.filePath}`,
             "--output",
-            `type=image,name=${registryService.createInternalContainerRegistryUrlForAppId(ctx.workload.id)},push=true,registry.insecure=true`
+            `type=image,name=${imageNames},push=true,registry.insecure=true`
         ];
 
         return {

--- a/src/server/services/build-job-builders/dockerfile-build-job-builder.service.unit.spec.ts
+++ b/src/server/services/build-job-builders/dockerfile-build-job-builder.service.unit.spec.ts
@@ -19,9 +19,11 @@ describe('DockerfileBuildJobBuilder', () => {
             latestRemoteGitCommitMessage: 'feat: test',
             queuedAt: '123',
             maxParallelBuilds: 2,
+            isRollback: true,
         });
 
         expect(job.metadata?.annotations?.['qs-build-method']).toBe('DOCKERFILE');
+        expect(job.metadata?.annotations?.['qs-is-rollback']).toBe('true');
         expect(job.spec?.template?.metadata?.annotations?.['qs-deplyoment-id']).toBe('deployment-1');
         expect(job.spec?.template?.spec?.initContainers?.map((container) => container.name)).toEqual([
             'build-queue-init',

--- a/src/server/services/build-job-builders/dockerfile-build-job-builder.service.unit.spec.ts
+++ b/src/server/services/build-job-builders/dockerfile-build-job-builder.service.unit.spec.ts
@@ -49,6 +49,9 @@ describe('DockerfileBuildJobBuilder', () => {
             'context=/workspace/source/apps/web',
             'dockerfile=/workspace/source/apps/web',
         ]));
+        expect(buildContainer.args).toEqual(expect.arrayContaining([
+            expect.stringContaining('name=registry-svc.registry-and-build.svc.cluster.local:5000/app-1:latest,registry-svc.registry-and-build.svc.cluster.local:5000/app-1:abc123'),
+        ]));
         expect(buildContainer.args).not.toContain('context=https://github.com/example/repo.git#refs/heads/main:./apps/web');
     });
 

--- a/src/server/services/build-job-builders/dockerfile-build-job-builder.service.unit.spec.ts
+++ b/src/server/services/build-job-builders/dockerfile-build-job-builder.service.unit.spec.ts
@@ -19,11 +19,10 @@ describe('DockerfileBuildJobBuilder', () => {
             latestRemoteGitCommitMessage: 'feat: test',
             queuedAt: '123',
             maxParallelBuilds: 2,
-            isRollback: true,
         });
 
         expect(job.metadata?.annotations?.['qs-build-method']).toBe('DOCKERFILE');
-        expect(job.metadata?.annotations?.['qs-is-rollback']).toBe('true');
+        expect(job.metadata?.annotations?.['qs-is-rollback']).toBeUndefined();
         expect(job.spec?.template?.metadata?.annotations?.['qs-deplyoment-id']).toBe('deployment-1');
         expect(job.spec?.template?.spec?.initContainers?.map((container) => container.name)).toEqual([
             'build-queue-init',
@@ -55,6 +54,32 @@ describe('DockerfileBuildJobBuilder', () => {
             expect.stringContaining('"name=registry-svc.registry-and-build.svc.cluster.local:5000/app-1:latest,registry-svc.registry-and-build.svc.cluster.local:5000/app-1:abc123"'),
         ]));
         expect(buildContainer.args).not.toContain('context=https://github.com/example/repo.git#refs/heads/main:./apps/web');
+    });
+
+    it('tags only the immutable commit tag when building a rollback', async () => {
+        const job = await dockerfileBuildJobBuilder.buildJobDefinition({
+            workload: {
+                id: 'app-1',
+                projectId: 'project-1',
+                gitUrl: 'https://github.com/example/repo.git',
+                gitBranch: 'main',
+                dockerfilePath: './Dockerfile',
+            } as any,
+            workloadType: 'app',
+            buildName: 'build-1',
+            deploymentId: 'deployment-1',
+            latestRemoteGitHash: 'abc123',
+            latestRemoteGitCommitMessage: 'old commit',
+            queuedAt: '123',
+            maxParallelBuilds: 2,
+            isRollback: true,
+        });
+
+        expect(job.metadata?.annotations?.['qs-is-rollback']).toBe('true');
+        expect(job.spec?.template?.metadata?.annotations?.['qs-is-rollback']).toBe('true');
+        const imageOutputArg = job.spec?.template?.spec?.containers[0]?.args?.find((arg) => arg.includes('type=image'));
+        expect(imageOutputArg).toContain('registry-svc.registry-and-build.svc.cluster.local:5000/app-1:abc123');
+        expect(imageOutputArg).not.toContain(':latest');
     });
 
     it('adds an SSH key secret volume when provided', async () => {

--- a/src/server/services/build-job-builders/dockerfile-build-job-builder.service.unit.spec.ts
+++ b/src/server/services/build-job-builders/dockerfile-build-job-builder.service.unit.spec.ts
@@ -50,7 +50,7 @@ describe('DockerfileBuildJobBuilder', () => {
             'dockerfile=/workspace/source/apps/web',
         ]));
         expect(buildContainer.args).toEqual(expect.arrayContaining([
-            expect.stringContaining('name=registry-svc.registry-and-build.svc.cluster.local:5000/app-1:latest,registry-svc.registry-and-build.svc.cluster.local:5000/app-1:abc123'),
+            expect.stringContaining('"name=registry-svc.registry-and-build.svc.cluster.local:5000/app-1:latest,registry-svc.registry-and-build.svc.cluster.local:5000/app-1:abc123"'),
         ]));
         expect(buildContainer.args).not.toContain('context=https://github.com/example/repo.git#refs/heads/main:./apps/web');
     });

--- a/src/server/services/build-job-builders/railpack-build-job-builder.service.ts
+++ b/src/server/services/build-job-builders/railpack-build-job-builder.service.ts
@@ -19,6 +19,10 @@ class RailpackBuildJobBuilder implements BuildJobBuilder {
     readonly buildMethod: AppBuildMethod = 'RAILPACK';
 
     async buildJobDefinition(ctx: BuildJobBuilderContext): Promise<V1Job> {
+        const imageNames = ctx.workloadType === 'app'
+            ? registryService.createInternalContainerRegistryImageNamesForApp(ctx.workload.id, ctx.latestRemoteGitHash)
+            : registryService.createInternalContainerRegistryUrlForAppId(ctx.workload.id);
+
         const buildkitArgs = [
             "build",
             "--local",
@@ -30,7 +34,7 @@ class RailpackBuildJobBuilder implements BuildJobBuilder {
             "--opt",
             `source=${RAILPACK_FRONTEND_IMAGE}`,
             "--output",
-            `type=image,name=${registryService.createInternalContainerRegistryUrlForAppId(ctx.workload.id)},push=true,registry.insecure=true`
+            `type=image,name=${imageNames},push=true,registry.insecure=true`
         ];
 
         return {

--- a/src/server/services/build-job-builders/railpack-build-job-builder.service.ts
+++ b/src/server/services/build-job-builders/railpack-build-job-builder.service.ts
@@ -53,6 +53,7 @@ class RailpackBuildJobBuilder implements BuildJobBuilder {
                     [Constants.QS_ANNOTATION_DEPLOYMENT_ID]: ctx.deploymentId,
                     [Constants.QS_ANNOTATION_BUILD_QUEUED_AT]: ctx.queuedAt,
                     [Constants.QS_ANNOTATION_BUILD_METHOD]: this.buildMethod,
+                    ...(ctx.isRollback ? { [Constants.QS_ANNOTATION_ROLLBACK]: 'true' } : {}),
                     ...(ctx.gitSshPrivateKeySecretName ? { [Constants.QS_ANNOTATION_GIT_SSH_SECRET]: ctx.gitSshPrivateKeySecretName } : {}),
                 }
             },
@@ -69,6 +70,7 @@ class RailpackBuildJobBuilder implements BuildJobBuilder {
                             [Constants.QS_ANNOTATION_GIT_COMMIT_MESSAGE]: ctx.latestRemoteGitCommitMessage.substring(0, 200),
                             [Constants.QS_ANNOTATION_DEPLOYMENT_ID]: ctx.deploymentId,
                             [Constants.QS_ANNOTATION_BUILD_METHOD]: this.buildMethod,
+                            ...(ctx.isRollback ? { [Constants.QS_ANNOTATION_ROLLBACK]: 'true' } : {}),
                             ...(ctx.gitSshPrivateKeySecretName ? { [Constants.QS_ANNOTATION_GIT_SSH_SECRET]: ctx.gitSshPrivateKeySecretName } : {}),
                         },
                     },

--- a/src/server/services/build-job-builders/railpack-build-job-builder.service.ts
+++ b/src/server/services/build-job-builders/railpack-build-job-builder.service.ts
@@ -1,11 +1,11 @@
 import { V1Container, V1Job } from "@kubernetes/client-node";
 import { BuildJobBuilder, BuildJobBuilderContext } from "./build-job-builder.interface";
 import { AppBuildMethod } from "@/shared/model/app-source-info.model";
-import { Constants } from "@/shared/utils/constants";
 import buildQueueInitContainer from "./build-init-container.service";
 import buildGitInitContainerService, { BUILD_GIT_SSH_KEY_VOLUME_NAME } from "./build-git-init-container.service";
 import registryService, { BUILD_NAMESPACE } from "../registry.service";
 import { BUILD_SOURCE_PATH, BUILD_WORKSPACE_MOUNT_PATH, BUILD_WORKSPACE_VOLUME_NAME, RAILPACK_PLAN_PATH } from "./build-workspace.constants";
+import { BuildJobAnnotationsUtils } from "./build-job-annotations.utils";
 
 const buildkitImage = "moby/buildkit:master";
 const railpackVersion = "0.15.1";
@@ -19,9 +19,7 @@ class RailpackBuildJobBuilder implements BuildJobBuilder {
     readonly buildMethod: AppBuildMethod = 'RAILPACK';
 
     async buildJobDefinition(ctx: BuildJobBuilderContext): Promise<V1Job> {
-        const imageNames = ctx.workloadType === 'app'
-            ? registryService.createInternalContainerRegistryImageNamesForApp(ctx.workload.id, ctx.latestRemoteGitHash)
-            : registryService.createInternalContainerRegistryUrlForAppId(ctx.workload.id);
+        const imageNames = registryService.createBuildImageNames(ctx.workload.id, ctx.workloadType, ctx.latestRemoteGitHash, ctx.isRollback);
 
         const buildkitArgs = [
             "build",
@@ -43,36 +41,13 @@ class RailpackBuildJobBuilder implements BuildJobBuilder {
             metadata: {
                 name: ctx.buildName,
                 namespace: BUILD_NAMESPACE,
-                annotations: {
-                    ...(ctx.workloadType === 'app' ? { [Constants.QS_ANNOTATION_APP_ID]: ctx.workload.id } : {}),
-                    ...(ctx.workloadType === 'agent' ? { [Constants.QS_ANNOTATION_AGENT_ID]: ctx.workload.id } : {}),
-                    [Constants.QS_ANNOTATION_WORKLOAD_TYPE]: ctx.workloadType,
-                    [Constants.QS_ANNOTATION_PROJECT_ID]: ctx.workload.projectId,
-                    [Constants.QS_ANNOTATION_GIT_COMMIT]: ctx.latestRemoteGitHash,
-                    [Constants.QS_ANNOTATION_GIT_COMMIT_MESSAGE]: ctx.latestRemoteGitCommitMessage.substring(0, 200),
-                    [Constants.QS_ANNOTATION_DEPLOYMENT_ID]: ctx.deploymentId,
-                    [Constants.QS_ANNOTATION_BUILD_QUEUED_AT]: ctx.queuedAt,
-                    [Constants.QS_ANNOTATION_BUILD_METHOD]: this.buildMethod,
-                    ...(ctx.isRollback ? { [Constants.QS_ANNOTATION_ROLLBACK]: 'true' } : {}),
-                    ...(ctx.gitSshPrivateKeySecretName ? { [Constants.QS_ANNOTATION_GIT_SSH_SECRET]: ctx.gitSshPrivateKeySecretName } : {}),
-                }
+                annotations: BuildJobAnnotationsUtils.createBuildJobAnnotations(ctx, this.buildMethod, true),
             },
             spec: {
                 ttlSecondsAfterFinished: 86400,
                 template: {
                     metadata: {
-                        annotations: {
-                            ...(ctx.workloadType === 'app' ? { [Constants.QS_ANNOTATION_APP_ID]: ctx.workload.id } : {}),
-                            ...(ctx.workloadType === 'agent' ? { [Constants.QS_ANNOTATION_AGENT_ID]: ctx.workload.id } : {}),
-                            [Constants.QS_ANNOTATION_WORKLOAD_TYPE]: ctx.workloadType,
-                            [Constants.QS_ANNOTATION_PROJECT_ID]: ctx.workload.projectId,
-                            [Constants.QS_ANNOTATION_GIT_COMMIT]: ctx.latestRemoteGitHash,
-                            [Constants.QS_ANNOTATION_GIT_COMMIT_MESSAGE]: ctx.latestRemoteGitCommitMessage.substring(0, 200),
-                            [Constants.QS_ANNOTATION_DEPLOYMENT_ID]: ctx.deploymentId,
-                            [Constants.QS_ANNOTATION_BUILD_METHOD]: this.buildMethod,
-                            ...(ctx.isRollback ? { [Constants.QS_ANNOTATION_ROLLBACK]: 'true' } : {}),
-                            ...(ctx.gitSshPrivateKeySecretName ? { [Constants.QS_ANNOTATION_GIT_SSH_SECRET]: ctx.gitSshPrivateKeySecretName } : {}),
-                        },
+                        annotations: BuildJobAnnotationsUtils.createBuildJobAnnotations(ctx, this.buildMethod),
                     },
                     spec: {
                         hostUsers: false,

--- a/src/server/services/build-job-builders/railpack-build-job-builder.service.ts
+++ b/src/server/services/build-job-builders/railpack-build-job-builder.service.ts
@@ -34,7 +34,7 @@ class RailpackBuildJobBuilder implements BuildJobBuilder {
             "--opt",
             `source=${RAILPACK_FRONTEND_IMAGE}`,
             "--output",
-            `type=image,name=${imageNames},push=true,registry.insecure=true`
+            `type=image,"name=${imageNames}",push=true,registry.insecure=true`
         ];
 
         return {

--- a/src/server/services/build-job-builders/railpack-build-job-builder.service.unit.spec.ts
+++ b/src/server/services/build-job-builders/railpack-build-job-builder.service.unit.spec.ts
@@ -42,6 +42,9 @@ describe('RailpackBuildJobBuilder', () => {
             'context=/workspace/source',
             'dockerfile=/workspace/plan',
         ]));
+        expect(buildContainer.args).toEqual(expect.arrayContaining([
+            expect.stringContaining('name=registry-svc.registry-and-build.svc.cluster.local:5000/app-1:latest,registry-svc.registry-and-build.svc.cluster.local:5000/app-1:abc123'),
+        ]));
 
         const prepareContainer = initContainers.find((container) => container.name === 'railpack-prepare-init')!;
         expect(prepareContainer.env?.map((entry) => entry.name)).not.toContain('GIT_URL');

--- a/src/server/services/build-job-builders/railpack-build-job-builder.service.unit.spec.ts
+++ b/src/server/services/build-job-builders/railpack-build-job-builder.service.unit.spec.ts
@@ -43,7 +43,7 @@ describe('RailpackBuildJobBuilder', () => {
             'dockerfile=/workspace/plan',
         ]));
         expect(buildContainer.args).toEqual(expect.arrayContaining([
-            expect.stringContaining('name=registry-svc.registry-and-build.svc.cluster.local:5000/app-1:latest,registry-svc.registry-and-build.svc.cluster.local:5000/app-1:abc123'),
+            expect.stringContaining('"name=registry-svc.registry-and-build.svc.cluster.local:5000/app-1:latest,registry-svc.registry-and-build.svc.cluster.local:5000/app-1:abc123"'),
         ]));
 
         const prepareContainer = initContainers.find((container) => container.name === 'railpack-prepare-init')!;

--- a/src/server/services/build-job-builders/railpack-build-job-builder.service.unit.spec.ts
+++ b/src/server/services/build-job-builders/railpack-build-job-builder.service.unit.spec.ts
@@ -18,12 +18,14 @@ describe('RailpackBuildJobBuilder', () => {
             latestRemoteGitCommitMessage: 'feat: test',
             queuedAt: '123',
             maxParallelBuilds: 2,
+            isRollback: true,
         });
 
         const initContainers = job.spec?.template?.spec?.initContainers ?? [];
         const buildContainer = job.spec?.template?.spec?.containers[0]!;
 
         expect(job.metadata?.annotations?.['qs-build-method']).toBe('RAILPACK');
+        expect(job.metadata?.annotations?.['qs-is-rollback']).toBe('true');
         expect(job.spec?.template?.metadata?.annotations?.['qs-deplyoment-id']).toBe('deployment-1');
         expect(initContainers.map((container) => container.name)).toEqual([
             'build-queue-init',

--- a/src/server/services/build-job-builders/railpack-build-job-builder.service.unit.spec.ts
+++ b/src/server/services/build-job-builders/railpack-build-job-builder.service.unit.spec.ts
@@ -18,14 +18,13 @@ describe('RailpackBuildJobBuilder', () => {
             latestRemoteGitCommitMessage: 'feat: test',
             queuedAt: '123',
             maxParallelBuilds: 2,
-            isRollback: true,
         });
 
         const initContainers = job.spec?.template?.spec?.initContainers ?? [];
         const buildContainer = job.spec?.template?.spec?.containers[0]!;
 
         expect(job.metadata?.annotations?.['qs-build-method']).toBe('RAILPACK');
-        expect(job.metadata?.annotations?.['qs-is-rollback']).toBe('true');
+        expect(job.metadata?.annotations?.['qs-is-rollback']).toBeUndefined();
         expect(job.spec?.template?.metadata?.annotations?.['qs-deplyoment-id']).toBe('deployment-1');
         expect(initContainers.map((container) => container.name)).toEqual([
             'build-queue-init',
@@ -51,5 +50,30 @@ describe('RailpackBuildJobBuilder', () => {
         const prepareContainer = initContainers.find((container) => container.name === 'railpack-prepare-init')!;
         expect(prepareContainer.env?.map((entry) => entry.name)).not.toContain('GIT_URL');
         expect(prepareContainer.args?.[0]).not.toContain('git clone');
+    });
+
+    it('tags only the immutable commit tag when building a rollback', async () => {
+        const job = await railpackBuildJobBuilder.buildJobDefinition({
+            workload: {
+                id: 'app-1',
+                projectId: 'project-1',
+                gitUrl: 'https://github.com/example/repo.git',
+                gitBranch: 'main',
+            } as any,
+            workloadType: 'app',
+            buildName: 'build-1',
+            deploymentId: 'deployment-1',
+            latestRemoteGitHash: 'abc123',
+            latestRemoteGitCommitMessage: 'old commit',
+            queuedAt: '123',
+            maxParallelBuilds: 2,
+            isRollback: true,
+        });
+
+        expect(job.metadata?.annotations?.['qs-is-rollback']).toBe('true');
+        expect(job.spec?.template?.metadata?.annotations?.['qs-is-rollback']).toBe('true');
+        const imageOutputArg = job.spec?.template?.spec?.containers[0]?.args?.find((arg) => arg.includes('type=image'));
+        expect(imageOutputArg).toContain('registry-svc.registry-and-build.svc.cluster.local:5000/app-1:abc123');
+        expect(imageOutputArg).not.toContain(':latest');
     });
 });

--- a/src/server/services/build.service.ts
+++ b/src/server/services/build.service.ts
@@ -22,7 +22,7 @@ import { KubeObjectNameUtils } from "../utils/kube-object-name.utils";
 import { V1JobStatus, V1ResourceRequirements } from "@kubernetes/client-node";
 import appGitSshKeyService from "./app-git-ssh-key.service";
 import agentGitSshKeyService from "./agent-git-ssh-key.service";
-import { shortGitHash } from "@/shared/utils/git-hash.utils";
+import { GitHashUtils } from "@/shared/utils/git-hash.utils";
 
 type BuildWorkload = AppExtendedModel | AgentExtendedModel;
 
@@ -81,7 +81,7 @@ class BuildService {
 
         if (!forceBuild && latestSuccessfulBuild?.gitCommit && latestRemoteGitHash &&
             latestSuccessfulBuild.gitCommit === latestRemoteGitHash) {
-            const imageTag = shortGitHash(latestRemoteGitHash) ?? 'latest';
+            const imageTag = GitHashUtils.shortGitHash(latestRemoteGitHash) ?? 'latest';
             if (await registryService.doesImageExist(workload.id, imageTag)) {
                 await dlog(deploymentId, `Latest build is already up to date with git repository, using container from last build.`);
                 return [latestSuccessfulBuild.name, latestRemoteGitHash, latestRemoteGitCommitMessage, true];

--- a/src/server/services/build.service.ts
+++ b/src/server/services/build.service.ts
@@ -23,24 +23,32 @@ import { V1JobStatus, V1ResourceRequirements } from "@kubernetes/client-node";
 import appGitSshKeyService from "./app-git-ssh-key.service";
 import agentGitSshKeyService from "./agent-git-ssh-key.service";
 import { GitHashUtils } from "@/shared/utils/git-hash.utils";
+import { BuildTargetSource } from "@/shared/model/deployment-source.model";
+import { RollbackAnnotationUtils } from "@/shared/utils/rollback-annotation.utils";
 
 type BuildWorkload = AppExtendedModel | AgentExtendedModel;
+
+type BuildWorkloadOptions = {
+    forceBuild?: boolean;
+    target?: BuildTargetSource;
+};
 
 class BuildService {
 
     async buildApp(deploymentId: string, app: AppExtendedModel, forceBuild: boolean = false): Promise<[string, string, string, boolean]> {
-        return this.buildWorkload(deploymentId, app, 'app', forceBuild);
+        return this.buildWorkload(deploymentId, app, 'app', { forceBuild });
     }
 
-    async buildAppAtCommit(deploymentId: string, app: AppExtendedModel, commitHash: string, commitMessage: string = '', isRollback: boolean = false): Promise<[string, string, string, boolean]> {
-        return this.buildWorkload(deploymentId, app, 'app', false, commitHash, commitMessage, isRollback);
+    async buildAppAtCommit(deploymentId: string, app: AppExtendedModel, target: BuildTargetSource): Promise<[string, string, string, boolean]> {
+        return this.buildWorkload(deploymentId, app, 'app', { target });
     }
 
     async buildAgent(deploymentId: string, agent: AgentExtendedModel, forceBuild: boolean = false): Promise<[string, string, string, boolean]> {
-        return this.buildWorkload(deploymentId, agent, 'agent', forceBuild);
+        return this.buildWorkload(deploymentId, agent, 'agent', { forceBuild });
     }
 
-    async buildWorkload(deploymentId: string, workload: BuildWorkload, workloadType: WorkloadType, forceBuild: boolean = false, targetCommitHash?: string, targetCommitMessage?: string, isRollback: boolean = false): Promise<[string, string, string, boolean]> {
+    async buildWorkload(deploymentId: string, workload: BuildWorkload, workloadType: WorkloadType, options: BuildWorkloadOptions = {}): Promise<[string, string, string, boolean]> {
+        const { forceBuild = false, target } = options;
         await namespaceService.createNamespaceIfNotExists(BUILD_NAMESPACE);
         const registryLocation = await paramService.getString(ParamService.REGISTRY_SOTRAGE_LOCATION, Constants.INTERNAL_REGISTRY_LOCATION);
         await registryService.deployRegistry(registryLocation!);
@@ -55,9 +63,9 @@ class BuildService {
         await dlog(deploymentId, `Selected build method: ${buildMethod}`);
         await dlog(deploymentId, `Trying to clone repository...`);
 
-        if (targetCommitHash) {
-            await dlog(deploymentId, `Building specific git commit ${targetCommitHash}...`);
-            return this.createAndStartBuildJob(deploymentId, workload, workloadType, targetCommitHash, targetCommitMessage ?? '', isRollback);
+        if (target) {
+            await dlog(deploymentId, `Building specific git commit ${target.gitCommitHash}...`);
+            return this.createAndStartBuildJob(deploymentId, workload, workloadType, target);
         }
 
         const latestSuccessfulBuild = buildsForWorkload.find(x => x.status === 'SUCCEEDED');
@@ -90,16 +98,17 @@ class BuildService {
             await dlog(deploymentId, `Docker Image for last build not found in internal registry, creating new build.`);
         }
 
-        return this.createAndStartBuildJob(deploymentId, workload, workloadType, latestRemoteGitHash, latestRemoteGitCommitMessage);
+        return this.createAndStartBuildJob(deploymentId, workload, workloadType, {
+            gitCommitHash: latestRemoteGitHash,
+            gitCommitMessage: latestRemoteGitCommitMessage,
+        });
     }
 
     private async createAndStartBuildJob(
         deploymentId: string,
         workload: BuildWorkload,
         workloadType: WorkloadType,
-        latestRemoteGitHash: string,
-        latestRemoteGitCommitMessage: string = '',
-        isRollback: boolean = false,
+        source: BuildTargetSource,
     ): Promise<[string, string, string, boolean]> {
         const buildName = KubeObjectNameUtils.addRandomSuffix(KubeObjectNameUtils.toJobName(workload.id));
         const buildMethod = this.getBuildMethod(workload, workloadType);
@@ -127,13 +136,13 @@ class BuildService {
                 workloadType,
                 buildName,
                 deploymentId,
-                latestRemoteGitHash,
-                latestRemoteGitCommitMessage,
+                latestRemoteGitHash: source.gitCommitHash,
+                latestRemoteGitCommitMessage: source.gitCommitMessage ?? '',
                 queuedAt,
                 ...schedulingConfig,
                 maxParallelBuilds,
                 gitSshPrivateKeySecretName,
-                isRollback,
+                isRollback: source.isRollback ?? false,
             });
 
             await k3s.batch.createNamespacedJob({ namespace: BUILD_NAMESPACE, body: jobDefinition });
@@ -143,7 +152,7 @@ class BuildService {
         }
         await dlog(deploymentId, `Build job ${buildName} scheduled successfully`);
 
-        return [buildName, latestRemoteGitHash, latestRemoteGitCommitMessage, false];
+        return [buildName, source.gitCommitHash, source.gitCommitMessage ?? '', false];
     }
 
     private getBuildMethod(workload: BuildWorkload, workloadType: WorkloadType): AppBuildMethod {
@@ -339,7 +348,7 @@ class BuildService {
             gitCommitMessage: job.metadata?.annotations?.[Constants.QS_ANNOTATION_GIT_COMMIT_MESSAGE],
             deploymentId: job.metadata?.annotations?.[Constants.QS_ANNOTATION_DEPLOYMENT_ID],
             buildMethod: job.metadata?.annotations?.[Constants.QS_ANNOTATION_BUILD_METHOD] as AppBuildMethod | undefined,
-            isRollback: job.metadata?.annotations?.[Constants.QS_ANNOTATION_ROLLBACK] === 'true',
+            isRollback: RollbackAnnotationUtils.isRollbackAnnotation(job.metadata?.annotations),
         } as BuildJobModel));
         builds.sort((a, b) => {
             if (a.startTime && b.startTime) {

--- a/src/server/services/build.service.ts
+++ b/src/server/services/build.service.ts
@@ -22,6 +22,7 @@ import { KubeObjectNameUtils } from "../utils/kube-object-name.utils";
 import { V1JobStatus, V1ResourceRequirements } from "@kubernetes/client-node";
 import appGitSshKeyService from "./app-git-ssh-key.service";
 import agentGitSshKeyService from "./agent-git-ssh-key.service";
+import { shortGitHash } from "@/shared/utils/git-hash.utils";
 
 type BuildWorkload = AppExtendedModel | AgentExtendedModel;
 
@@ -31,11 +32,15 @@ class BuildService {
         return this.buildWorkload(deploymentId, app, 'app', forceBuild);
     }
 
+    async buildAppAtCommit(deploymentId: string, app: AppExtendedModel, commitHash: string, commitMessage: string = ''): Promise<[string, string, string, boolean]> {
+        return this.buildWorkload(deploymentId, app, 'app', false, commitHash, commitMessage);
+    }
+
     async buildAgent(deploymentId: string, agent: AgentExtendedModel, forceBuild: boolean = false): Promise<[string, string, string, boolean]> {
         return this.buildWorkload(deploymentId, agent, 'agent', forceBuild);
     }
 
-    async buildWorkload(deploymentId: string, workload: BuildWorkload, workloadType: WorkloadType, forceBuild: boolean = false): Promise<[string, string, string, boolean]> {
+    async buildWorkload(deploymentId: string, workload: BuildWorkload, workloadType: WorkloadType, forceBuild: boolean = false, targetCommitHash?: string, targetCommitMessage?: string): Promise<[string, string, string, boolean]> {
         await namespaceService.createNamespaceIfNotExists(BUILD_NAMESPACE);
         const registryLocation = await paramService.getString(ParamService.REGISTRY_SOTRAGE_LOCATION, Constants.INTERNAL_REGISTRY_LOCATION);
         await registryService.deployRegistry(registryLocation!);
@@ -49,6 +54,11 @@ class BuildService {
         await dlog(deploymentId, `Initialized ${workloadType} build...`);
         await dlog(deploymentId, `Selected build method: ${buildMethod}`);
         await dlog(deploymentId, `Trying to clone repository...`);
+
+        if (targetCommitHash) {
+            await dlog(deploymentId, `Building specific git commit ${targetCommitHash}...`);
+            return this.createAndStartBuildJob(deploymentId, workload, workloadType, targetCommitHash, targetCommitMessage ?? '');
+        }
 
         const latestSuccessfulBuild = buildsForWorkload.find(x => x.status === 'SUCCEEDED');
         const { latestRemoteGitHash, latestRemoteGitCommitMessage } = await gitService.openGitContext({
@@ -71,7 +81,8 @@ class BuildService {
 
         if (!forceBuild && latestSuccessfulBuild?.gitCommit && latestRemoteGitHash &&
             latestSuccessfulBuild.gitCommit === latestRemoteGitHash) {
-            if (await registryService.doesImageExist(workload.id, 'latest')) {
+            const imageTag = shortGitHash(latestRemoteGitHash) ?? 'latest';
+            if (await registryService.doesImageExist(workload.id, imageTag)) {
                 await dlog(deploymentId, `Latest build is already up to date with git repository, using container from last build.`);
                 return [latestSuccessfulBuild.name, latestRemoteGitHash, latestRemoteGitCommitMessage, true];
             }

--- a/src/server/services/build.service.ts
+++ b/src/server/services/build.service.ts
@@ -32,15 +32,15 @@ class BuildService {
         return this.buildWorkload(deploymentId, app, 'app', forceBuild);
     }
 
-    async buildAppAtCommit(deploymentId: string, app: AppExtendedModel, commitHash: string, commitMessage: string = ''): Promise<[string, string, string, boolean]> {
-        return this.buildWorkload(deploymentId, app, 'app', false, commitHash, commitMessage);
+    async buildAppAtCommit(deploymentId: string, app: AppExtendedModel, commitHash: string, commitMessage: string = '', isRollback: boolean = false): Promise<[string, string, string, boolean]> {
+        return this.buildWorkload(deploymentId, app, 'app', false, commitHash, commitMessage, isRollback);
     }
 
     async buildAgent(deploymentId: string, agent: AgentExtendedModel, forceBuild: boolean = false): Promise<[string, string, string, boolean]> {
         return this.buildWorkload(deploymentId, agent, 'agent', forceBuild);
     }
 
-    async buildWorkload(deploymentId: string, workload: BuildWorkload, workloadType: WorkloadType, forceBuild: boolean = false, targetCommitHash?: string, targetCommitMessage?: string): Promise<[string, string, string, boolean]> {
+    async buildWorkload(deploymentId: string, workload: BuildWorkload, workloadType: WorkloadType, forceBuild: boolean = false, targetCommitHash?: string, targetCommitMessage?: string, isRollback: boolean = false): Promise<[string, string, string, boolean]> {
         await namespaceService.createNamespaceIfNotExists(BUILD_NAMESPACE);
         const registryLocation = await paramService.getString(ParamService.REGISTRY_SOTRAGE_LOCATION, Constants.INTERNAL_REGISTRY_LOCATION);
         await registryService.deployRegistry(registryLocation!);
@@ -57,7 +57,7 @@ class BuildService {
 
         if (targetCommitHash) {
             await dlog(deploymentId, `Building specific git commit ${targetCommitHash}...`);
-            return this.createAndStartBuildJob(deploymentId, workload, workloadType, targetCommitHash, targetCommitMessage ?? '');
+            return this.createAndStartBuildJob(deploymentId, workload, workloadType, targetCommitHash, targetCommitMessage ?? '', isRollback);
         }
 
         const latestSuccessfulBuild = buildsForWorkload.find(x => x.status === 'SUCCEEDED');
@@ -99,6 +99,7 @@ class BuildService {
         workloadType: WorkloadType,
         latestRemoteGitHash: string,
         latestRemoteGitCommitMessage: string = '',
+        isRollback: boolean = false,
     ): Promise<[string, string, string, boolean]> {
         const buildName = KubeObjectNameUtils.addRandomSuffix(KubeObjectNameUtils.toJobName(workload.id));
         const buildMethod = this.getBuildMethod(workload, workloadType);
@@ -132,6 +133,7 @@ class BuildService {
                 ...schedulingConfig,
                 maxParallelBuilds,
                 gitSshPrivateKeySecretName,
+                isRollback,
             });
 
             await k3s.batch.createNamespacedJob({ namespace: BUILD_NAMESPACE, body: jobDefinition });
@@ -337,6 +339,7 @@ class BuildService {
             gitCommitMessage: job.metadata?.annotations?.[Constants.QS_ANNOTATION_GIT_COMMIT_MESSAGE],
             deploymentId: job.metadata?.annotations?.[Constants.QS_ANNOTATION_DEPLOYMENT_ID],
             buildMethod: job.metadata?.annotations?.[Constants.QS_ANNOTATION_BUILD_METHOD] as AppBuildMethod | undefined,
+            isRollback: job.metadata?.annotations?.[Constants.QS_ANNOTATION_ROLLBACK] === 'true',
         } as BuildJobModel));
         builds.sort((a, b) => {
             if (a.startTime && b.startTime) {

--- a/src/server/services/deployment.service.ts
+++ b/src/server/services/deployment.service.ts
@@ -353,6 +353,7 @@ class DeploymentService {
                 gitCommitMessage: build.gitCommitMessage,
                 deploymentId: build.deploymentId,
                 buildMethod: build.buildMethod,
+                isRollback: build.isRollback,
                 }
             });
         replicasetRevisions.push(...runningOrFailedBuilds);

--- a/src/server/services/deployment.service.ts
+++ b/src/server/services/deployment.service.ts
@@ -23,6 +23,8 @@ import { z } from "zod";
 import { ContainerCommangArgsUtils } from "@/shared/utils/container-command-args.utils";
 import { AppBuildMethod } from "@/shared/model/app-source-info.model";
 import { GitHashUtils } from "@/shared/utils/git-hash.utils";
+import { DeploymentSource } from "@/shared/model/deployment-source.model";
+import { RollbackAnnotationUtils } from "@/shared/utils/rollback-annotation.utils";
 
 class DeploymentService {
 
@@ -82,12 +84,9 @@ class DeploymentService {
     async createDeployment(
         deploymentId: string,
         app: AppExtendedModel,
-        buildJobName?: string,
-        gitCommitHash?: string,
-        gitCommitMessage?: string,
-        buildMethod?: AppBuildMethod,
-        isRollback?: boolean,
+        source?: DeploymentSource,
     ) {
+        const { buildJobName, gitCommitHash, gitCommitMessage, buildMethod, isRollback } = source ?? {};
         await this.validateDeployment(app);
 
         dlog(deploymentId, `Shutting down FileBrowsers (if active)`);
@@ -146,7 +145,7 @@ class DeploymentService {
                             [Constants.QS_ANNOTATION_DEPLOYMENT_ID]: deploymentId,
                             deploymentTimestamp: new Date().getTime() + "",
                             "kubernetes.io/change-cause": `Deployment ${new Date().toISOString()}`,
-                            ...(isRollback ? { [Constants.QS_ANNOTATION_ROLLBACK]: 'true' } : {}),
+                            ...RollbackAnnotationUtils.rollbackAnnotation(isRollback),
                         }
                     },
                     spec: {
@@ -397,7 +396,7 @@ class DeploymentService {
                 status: status,
                 deploymentId: rs.spec?.template?.metadata?.annotations?.[Constants.QS_ANNOTATION_DEPLOYMENT_ID]!,
                 buildMethod: rs.spec?.template?.metadata?.annotations?.[Constants.QS_ANNOTATION_BUILD_METHOD] as AppBuildMethod | undefined,
-                isRollback: rs.spec?.template?.metadata?.annotations?.[Constants.QS_ANNOTATION_ROLLBACK] === 'true',
+                isRollback: RollbackAnnotationUtils.isRollbackAnnotation(rs.spec?.template?.metadata?.annotations),
             }
         });
         return ListUtils.sortByDate(revisions, (i) => i.createdAt!, true);

--- a/src/server/services/deployment.service.ts
+++ b/src/server/services/deployment.service.ts
@@ -22,6 +22,7 @@ import networkPolicyService from "./network-policy.service";
 import { z } from "zod";
 import { ContainerCommangArgsUtils } from "@/shared/utils/container-command-args.utils";
 import { AppBuildMethod } from "@/shared/model/app-source-info.model";
+import { shortGitHash } from "@/shared/utils/git-hash.utils";
 
 class DeploymentService {
 
@@ -85,6 +86,7 @@ class DeploymentService {
         gitCommitHash?: string,
         gitCommitMessage?: string,
         buildMethod?: AppBuildMethod,
+        isRollback?: boolean,
     ) {
         await this.validateDeployment(app);
 
@@ -143,14 +145,15 @@ class DeploymentService {
                             [Constants.QS_ANNOTATION_PROJECT_ID]: app.projectId,
                             [Constants.QS_ANNOTATION_DEPLOYMENT_ID]: deploymentId,
                             deploymentTimestamp: new Date().getTime() + "",
-                            "kubernetes.io/change-cause": `Deployment ${new Date().toISOString()}`
+                            "kubernetes.io/change-cause": `Deployment ${new Date().toISOString()}`,
+                            ...(isRollback ? { [Constants.QS_ANNOTATION_ROLLBACK]: 'true' } : {}),
                         }
                     },
                     spec: {
                         containers: [
                             {
                                 name: app.id,
-                                image: !!buildJobName ? registryService.createContainerRegistryUrlForAppId(app.id) : app.containerImageSource as string,
+                                image: (buildJobName || gitCommitHash) ? registryService.createContainerRegistryUrlForAppId(app.id, shortGitHash(gitCommitHash)) : app.containerImageSource as string,
                                 imagePullPolicy: 'Always',
                                 ...(app.containerCommand ? { command: ContainerCommangArgsUtils.parseStoredContainerCommandArray(app.containerCommand) ?? undefined } : {}),
                                 ...(app.containerArgs ? { args: JSON.parse(app.containerArgs) } : {}),
@@ -393,6 +396,7 @@ class DeploymentService {
                 status: status,
                 deploymentId: rs.spec?.template?.metadata?.annotations?.[Constants.QS_ANNOTATION_DEPLOYMENT_ID]!,
                 buildMethod: rs.spec?.template?.metadata?.annotations?.[Constants.QS_ANNOTATION_BUILD_METHOD] as AppBuildMethod | undefined,
+                isRollback: rs.spec?.template?.metadata?.annotations?.[Constants.QS_ANNOTATION_ROLLBACK] === 'true',
             }
         });
         return ListUtils.sortByDate(revisions, (i) => i.createdAt!, true);

--- a/src/server/services/deployment.service.ts
+++ b/src/server/services/deployment.service.ts
@@ -22,7 +22,7 @@ import networkPolicyService from "./network-policy.service";
 import { z } from "zod";
 import { ContainerCommangArgsUtils } from "@/shared/utils/container-command-args.utils";
 import { AppBuildMethod } from "@/shared/model/app-source-info.model";
-import { shortGitHash } from "@/shared/utils/git-hash.utils";
+import { GitHashUtils } from "@/shared/utils/git-hash.utils";
 
 class DeploymentService {
 
@@ -153,7 +153,7 @@ class DeploymentService {
                         containers: [
                             {
                                 name: app.id,
-                                image: (buildJobName || gitCommitHash) ? registryService.createContainerRegistryUrlForAppId(app.id, shortGitHash(gitCommitHash)) : app.containerImageSource as string,
+                                image: (buildJobName || gitCommitHash) ? registryService.createContainerRegistryUrlForAppId(app.id, GitHashUtils.shortGitHash(gitCommitHash)) : app.containerImageSource as string,
                                 imagePullPolicy: 'Always',
                                 ...(app.containerCommand ? { command: ContainerCommangArgsUtils.parseStoredContainerCommandArray(app.containerCommand) ?? undefined } : {}),
                                 ...(app.containerArgs ? { args: JSON.parse(app.containerArgs) } : {}),

--- a/src/server/services/registry.service.ts
+++ b/src/server/services/registry.service.ts
@@ -9,7 +9,7 @@ import s3TargetService from "./s3-target.service";
 import clusterService from "./cluster.service";
 import { ServiceException } from "@/shared/model/service.exception.model";
 import s3Adapter from "../adapter/aws-s3.adapter";
-import { shortGitHash } from "@/shared/utils/git-hash.utils";
+import { GitHashUtils } from "@/shared/utils/git-hash.utils";
 
 const REGISTRY_NODE_PORT = 30100;
 const REGISTRY_CONTAINER_PORT = 5000;
@@ -75,7 +75,7 @@ class RegistryService {
 
     createInternalContainerRegistryImageNamesForApp(appId: string, commitHash?: string | null) {
         const latest = this.createInternalContainerRegistryUrlForAppId(appId);
-        const commitTag = shortGitHash(commitHash);
+        const commitTag = GitHashUtils.shortGitHash(commitHash);
         if (!latest || !commitTag) {
             return latest;
         }

--- a/src/server/services/registry.service.ts
+++ b/src/server/services/registry.service.ts
@@ -9,6 +9,7 @@ import s3TargetService from "./s3-target.service";
 import clusterService from "./cluster.service";
 import { ServiceException } from "@/shared/model/service.exception.model";
 import s3Adapter from "../adapter/aws-s3.adapter";
+import { shortGitHash } from "@/shared/utils/git-hash.utils";
 
 const REGISTRY_NODE_PORT = 30100;
 const REGISTRY_CONTAINER_PORT = 5000;
@@ -58,18 +59,27 @@ class RegistryService {
         return false;
     }
 
-    createInternalContainerRegistryUrlForAppId(appId?: string) {
+    createInternalContainerRegistryUrlForAppId(appId?: string, tag?: string) {
         if (!appId) {
             return undefined;
         }
-        return `${REGISTRY_URL_INTERNAL}/${appId}:latest`;
+        return `${REGISTRY_URL_INTERNAL}/${appId}:${tag || 'latest'}`;
     }
 
-    createContainerRegistryUrlForAppId(appId?: string) {
+    createContainerRegistryUrlForAppId(appId?: string, tag?: string) {
         if (!appId) {
             return undefined;
         }
-        return `${REGISTRY_URL_EXTERNAL}/${appId}:latest`;
+        return `${REGISTRY_URL_EXTERNAL}/${appId}:${tag || 'latest'}`;
+    }
+
+    createInternalContainerRegistryImageNamesForApp(appId: string, commitHash?: string | null) {
+        const latest = this.createInternalContainerRegistryUrlForAppId(appId);
+        const commitTag = shortGitHash(commitHash);
+        if (!latest || !commitTag) {
+            return latest;
+        }
+        return `${latest},${this.createInternalContainerRegistryUrlForAppId(appId, commitTag)}`;
     }
 
     async deployRegistry(registryLocation: string, forceDeploy = false) {

--- a/src/server/services/registry.service.ts
+++ b/src/server/services/registry.service.ts
@@ -10,6 +10,7 @@ import clusterService from "./cluster.service";
 import { ServiceException } from "@/shared/model/service.exception.model";
 import s3Adapter from "../adapter/aws-s3.adapter";
 import { GitHashUtils } from "@/shared/utils/git-hash.utils";
+import { WorkloadType } from "@/shared/model/runtime-type.model";
 
 const REGISTRY_NODE_PORT = 30100;
 const REGISTRY_CONTAINER_PORT = 5000;
@@ -59,27 +60,25 @@ class RegistryService {
         return false;
     }
 
-    createInternalContainerRegistryUrlForAppId(appId?: string, tag?: string) {
-        if (!appId) {
-            return undefined;
-        }
+    createInternalContainerRegistryUrlForAppId(appId: string, tag?: string) {
         return `${REGISTRY_URL_INTERNAL}/${appId}:${tag || 'latest'}`;
     }
 
-    createContainerRegistryUrlForAppId(appId?: string, tag?: string) {
-        if (!appId) {
-            return undefined;
-        }
+    createContainerRegistryUrlForAppId(appId: string, tag?: string) {
         return `${REGISTRY_URL_EXTERNAL}/${appId}:${tag || 'latest'}`;
     }
 
-    createInternalContainerRegistryImageNamesForApp(appId: string, commitHash?: string | null) {
-        const latest = this.createInternalContainerRegistryUrlForAppId(appId);
-        const commitTag = GitHashUtils.shortGitHash(commitHash);
-        if (!latest || !commitTag) {
-            return latest;
+    createBuildImageNames(appId: string, workloadType: WorkloadType, commitHash?: string | null, isRollback = false) {
+        if (workloadType === 'agent') {
+            return this.createContainerRegistryUrlForAppId(appId);
         }
-        return `${latest},${this.createInternalContainerRegistryUrlForAppId(appId, commitTag)}`;
+        const latestTag = this.createInternalContainerRegistryUrlForAppId(appId);
+        const commitTag = GitHashUtils.shortGitHash(commitHash);
+        if (!commitTag) {
+            return latestTag;
+        }
+        const commitTagUrl = this.createInternalContainerRegistryUrlForAppId(appId, commitTag);
+        return isRollback ? commitTagUrl : `${latestTag},${commitTagUrl}`;
     }
 
     async deployRegistry(registryLocation: string, forceDeploy = false) {

--- a/src/server/services/standalone-services/build-watch.service.ts
+++ b/src/server/services/standalone-services/build-watch.service.ts
@@ -10,6 +10,7 @@ import { dlog } from '../deployment-logs.service';
 import { BUILD_NAMESPACE } from '../registry.service';
 import { AppBuildMethod } from '@/shared/model/app-source-info.model';
 import appGitSshKeyService from '../app-git-ssh-key.service';
+import { RollbackAnnotationUtils } from '@/shared/utils/rollback-annotation.utils';
 
 declare global {
     var buildWatchServiceInstance: BuildWatchService | undefined;
@@ -76,7 +77,7 @@ class BuildWatchService {
         const buildJobName = job.metadata?.name;
         const buildMethod = job.metadata?.annotations?.[Constants.QS_ANNOTATION_BUILD_METHOD] as AppBuildMethod | undefined;
         const gitSshSecretName = job.metadata?.annotations?.[Constants.QS_ANNOTATION_GIT_SSH_SECRET];
-        const isRollback = job.metadata?.annotations?.[Constants.QS_ANNOTATION_ROLLBACK] === 'true';
+        const isRollback = RollbackAnnotationUtils.isRollbackAnnotation(job.metadata?.annotations);
 
         if (!deploymentId || !buildJobName || (workloadType === 'app' && !appId) || (workloadType === 'agent' && !agentId)) {
             console.error('[BuildWatch] handleSucceeded: missing required annotations on job', job.metadata?.name);
@@ -93,15 +94,13 @@ class BuildWatchService {
                 await agentService.deployBuiltAgent(agentId!, deploymentId, buildJobName, gitCommitHash, gitCommitMessage);
             } else {
                 const app = await appService.getExtendedById(appId!, false);
-                await deploymentService.createDeployment(
-                    deploymentId,
-                    app,
+                await deploymentService.createDeployment(deploymentId, app, {
                     buildJobName,
                     gitCommitHash,
                     gitCommitMessage,
-                    buildMethod ?? (app.buildMethod === 'DOCKERFILE' ? 'DOCKERFILE' : 'RAILPACK'),
+                    buildMethod: buildMethod ?? (app.buildMethod === 'DOCKERFILE' ? 'DOCKERFILE' : 'RAILPACK'),
                     isRollback,
-                );
+                });
             }
         } catch (e) {
             console.error(`[BuildWatch] Error triggering deployment for ${workloadType} ${appId ?? agentId}:`, e);

--- a/src/server/services/standalone-services/build-watch.service.ts
+++ b/src/server/services/standalone-services/build-watch.service.ts
@@ -76,6 +76,7 @@ class BuildWatchService {
         const buildJobName = job.metadata?.name;
         const buildMethod = job.metadata?.annotations?.[Constants.QS_ANNOTATION_BUILD_METHOD] as AppBuildMethod | undefined;
         const gitSshSecretName = job.metadata?.annotations?.[Constants.QS_ANNOTATION_GIT_SSH_SECRET];
+        const isRollback = job.metadata?.annotations?.[Constants.QS_ANNOTATION_ROLLBACK] === 'true';
 
         if (!deploymentId || !buildJobName || (workloadType === 'app' && !appId) || (workloadType === 'agent' && !agentId)) {
             console.error('[BuildWatch] handleSucceeded: missing required annotations on job', job.metadata?.name);
@@ -99,6 +100,7 @@ class BuildWatchService {
                     gitCommitHash,
                     gitCommitMessage,
                     buildMethod ?? (app.buildMethod === 'DOCKERFILE' ? 'DOCKERFILE' : 'RAILPACK'),
+                    isRollback,
                 );
             }
         } catch (e) {

--- a/src/server/services/standalone-services/build-watch.service.unit.spec.ts
+++ b/src/server/services/standalone-services/build-watch.service.unit.spec.ts
@@ -112,11 +112,13 @@ describe('BuildWatchService', () => {
         expect(deploymentService.createDeployment).toHaveBeenCalledWith(
             'deployment-1',
             expect.anything(),
-            'build-1',
-            'abc123',
-            'feat: test',
-            'RAILPACK',
-            true,
+            expect.objectContaining({
+                buildJobName: 'build-1',
+                gitCommitHash: 'abc123',
+                gitCommitMessage: 'feat: test',
+                buildMethod: 'RAILPACK',
+                isRollback: true,
+            }),
         );
         expect(appGitSshKeyService.deleteTemporaryBuildSecret).toHaveBeenCalledWith('git-ssh-build-1');
     });

--- a/src/server/services/standalone-services/build-watch.service.unit.spec.ts
+++ b/src/server/services/standalone-services/build-watch.service.unit.spec.ts
@@ -103,12 +103,21 @@ describe('BuildWatchService', () => {
                     'qs-git-commit': 'abc123',
                     'qs-git-commit-message': 'feat: test',
                     'qs-build-method': 'RAILPACK',
+                    'qs-is-rollback': 'true',
                     'qs-git-ssh-secret': 'git-ssh-build-1',
                 },
             },
         });
 
-        expect(deploymentService.createDeployment).toHaveBeenCalled();
+        expect(deploymentService.createDeployment).toHaveBeenCalledWith(
+            'deployment-1',
+            expect.anything(),
+            'build-1',
+            'abc123',
+            'feat: test',
+            'RAILPACK',
+            true,
+        );
         expect(appGitSshKeyService.deleteTemporaryBuildSecret).toHaveBeenCalledWith('git-ssh-build-1');
     });
 });

--- a/src/shared/model/build-job.ts
+++ b/src/shared/model/build-job.ts
@@ -14,6 +14,7 @@ export const buildJobSchemaZod = z.object({
     gitCommitMessage: z.string().optional(),
     deploymentId: z.string(),
     buildMethod: appBuildMethodZodModel.optional(),
+    isRollback: z.boolean().optional(),
 });
 
 export type BuildJobModel = z.infer<typeof buildJobSchemaZod>;

--- a/src/shared/model/deployment-info.model.ts
+++ b/src/shared/model/deployment-info.model.ts
@@ -21,6 +21,7 @@ export const deploymentInfoZodModel = z.object({
     gitCommitMessage: z.string().optional(),
     deploymentId: z.string(),
     buildMethod: appBuildMethodZodModel.optional(),
+    isRollback: z.boolean().optional(),
 });
 
 export const deploymentDetailsResponseZodModel = deploymentInfoZodModel.omit({

--- a/src/shared/model/deployment-source.model.ts
+++ b/src/shared/model/deployment-source.model.ts
@@ -1,0 +1,12 @@
+import { AppBuildMethod } from "./app-source-info.model";
+
+export type BuildTargetSource = {
+    gitCommitHash: string;
+    gitCommitMessage?: string;
+    isRollback?: boolean;
+};
+
+export type DeploymentSource = Partial<BuildTargetSource> & {
+    buildJobName?: string;
+    buildMethod?: AppBuildMethod;
+};

--- a/src/shared/utils/constants.ts
+++ b/src/shared/utils/constants.ts
@@ -15,6 +15,7 @@ export class Constants {
     static readonly QS_ANNOTATION_GIT_COMMIT = 'qs-git-commit';
     static readonly QS_ANNOTATION_GIT_COMMIT_MESSAGE = 'qs-git-commit-message';
     static readonly QS_ANNOTATION_ROLLBACK = 'qs-is-rollback';
+    static readonly QS_ANNOTATION_VALUE_TRUE = 'true';
     static readonly QS_ANNOTATION_BUILD_QUEUED_AT = 'qs-build-queued-at';
     static readonly QS_ANNOTATION_BUILD_METHOD = 'qs-build-method';
     static readonly QS_ANNOTATION_GIT_SSH_SECRET = 'qs-git-ssh-secret';

--- a/src/shared/utils/constants.ts
+++ b/src/shared/utils/constants.ts
@@ -14,6 +14,7 @@ export class Constants {
     static readonly QS_ANNOTATION_DEPLOYMENT_ID = 'qs-deplyoment-id';
     static readonly QS_ANNOTATION_GIT_COMMIT = 'qs-git-commit';
     static readonly QS_ANNOTATION_GIT_COMMIT_MESSAGE = 'qs-git-commit-message';
+    static readonly QS_ANNOTATION_ROLLBACK = 'qs-is-rollback';
     static readonly QS_ANNOTATION_BUILD_QUEUED_AT = 'qs-build-queued-at';
     static readonly QS_ANNOTATION_BUILD_METHOD = 'qs-build-method';
     static readonly QS_ANNOTATION_GIT_SSH_SECRET = 'qs-git-ssh-secret';

--- a/src/shared/utils/git-hash.utils.ts
+++ b/src/shared/utils/git-hash.utils.ts
@@ -1,0 +1,8 @@
+const GIT_COMMIT_TAG_LENGTH = 12;
+
+export function shortGitHash(hash?: string | null): string | undefined {
+    if (!hash) {
+        return undefined;
+    }
+    return hash.slice(0, GIT_COMMIT_TAG_LENGTH);
+}

--- a/src/shared/utils/git-hash.utils.ts
+++ b/src/shared/utils/git-hash.utils.ts
@@ -1,8 +1,10 @@
-const GIT_COMMIT_TAG_LENGTH = 12;
+const GIT_COMMIT_TAG_LENGTH = 7;
 
-export function shortGitHash(hash?: string | null): string | undefined {
-    if (!hash) {
-        return undefined;
+export class GitHashUtils {
+    static shortGitHash(hash?: string | null): string | undefined {
+        if (!hash) {
+            return undefined;
+        }
+        return hash.slice(0, GIT_COMMIT_TAG_LENGTH);
     }
-    return hash.slice(0, GIT_COMMIT_TAG_LENGTH);
 }

--- a/src/shared/utils/git-hash.utils.unit.spec.ts
+++ b/src/shared/utils/git-hash.utils.unit.spec.ts
@@ -1,0 +1,17 @@
+import { shortGitHash } from "./git-hash.utils";
+
+describe('shortGitHash', () => {
+    it('returns undefined for undefined and null', () => {
+        expect(shortGitHash(undefined)).toBeUndefined();
+        expect(shortGitHash(null)).toBeUndefined();
+        expect(shortGitHash('')).toBeUndefined();
+    });
+
+    it('returns the first 12 characters of a full hash', () => {
+        expect(shortGitHash('abcdef1234567890')).toBe('abcdef123456');
+    });
+
+    it('returns the whole hash when it is shorter than 12 characters', () => {
+        expect(shortGitHash('abc123')).toBe('abc123');
+    });
+});

--- a/src/shared/utils/git-hash.utils.unit.spec.ts
+++ b/src/shared/utils/git-hash.utils.unit.spec.ts
@@ -1,17 +1,17 @@
-import { shortGitHash } from "./git-hash.utils";
+import { GitHashUtils } from "./git-hash.utils";
 
-describe('shortGitHash', () => {
+describe('GitHashUtils.shortGitHash', () => {
     it('returns undefined for undefined and null', () => {
-        expect(shortGitHash(undefined)).toBeUndefined();
-        expect(shortGitHash(null)).toBeUndefined();
-        expect(shortGitHash('')).toBeUndefined();
+        expect(GitHashUtils.shortGitHash(undefined)).toBeUndefined();
+        expect(GitHashUtils.shortGitHash(null)).toBeUndefined();
+        expect(GitHashUtils.shortGitHash('')).toBeUndefined();
     });
 
-    it('returns the first 12 characters of a full hash', () => {
-        expect(shortGitHash('abcdef1234567890')).toBe('abcdef123456');
+    it('returns the first 7 characters of a full hash', () => {
+        expect(GitHashUtils.shortGitHash('abcdef1234567890')).toBe('abcdef1');
     });
 
-    it('returns the whole hash when it is shorter than 12 characters', () => {
-        expect(shortGitHash('abc123')).toBe('abc123');
+    it('returns the whole hash when it is shorter than 7 characters', () => {
+        expect(GitHashUtils.shortGitHash('abc123')).toBe('abc123');
     });
 });

--- a/src/shared/utils/rollback-annotation.utils.ts
+++ b/src/shared/utils/rollback-annotation.utils.ts
@@ -1,0 +1,11 @@
+import { Constants } from "./constants";
+
+export class RollbackAnnotationUtils {
+    static isRollbackAnnotation(annotations?: { [key: string]: string }): boolean {
+        return annotations?.[Constants.QS_ANNOTATION_ROLLBACK] === Constants.QS_ANNOTATION_VALUE_TRUE;
+    }
+
+    static rollbackAnnotation(isRollback?: boolean): Record<string, string> {
+        return isRollback ? { [Constants.QS_ANNOTATION_ROLLBACK]: Constants.QS_ANNOTATION_VALUE_TRUE } : {};
+    }
+}

--- a/src/shared/utils/rollback-annotation.utils.unit.spec.ts
+++ b/src/shared/utils/rollback-annotation.utils.unit.spec.ts
@@ -1,0 +1,20 @@
+import { RollbackAnnotationUtils } from "./rollback-annotation.utils";
+
+describe('RollbackAnnotationUtils', () => {
+    it('rollbackAnnotation returns an empty map when not rolling back', () => {
+        expect(RollbackAnnotationUtils.rollbackAnnotation()).toEqual({});
+        expect(RollbackAnnotationUtils.rollbackAnnotation(false)).toEqual({});
+    });
+
+    it('rollbackAnnotation returns the rollback entry when rolling back', () => {
+        expect(RollbackAnnotationUtils.rollbackAnnotation(true)).toEqual({ 'qs-is-rollback': 'true' });
+    });
+
+    it('isRollbackAnnotation reads the rollback value from an annotation map', () => {
+        expect(RollbackAnnotationUtils.isRollbackAnnotation(undefined)).toBe(false);
+        expect(RollbackAnnotationUtils.isRollbackAnnotation({})).toBe(false);
+        expect(RollbackAnnotationUtils.isRollbackAnnotation({ 'qs-is-rollback': 'true' })).toBe(true);
+        expect(RollbackAnnotationUtils.isRollbackAnnotation({ 'qs-is-rollback': 'false' })).toBe(false);
+        expect(RollbackAnnotationUtils.isRollbackAnnotation({ 'some-other': 'true' })).toBe(false);
+    });
+});


### PR DESCRIPTION
## Summary

Adds rollback support for git deployments (closes #35).

Git build images are now tagged with both `latest` and the short commit hash. Deployments reference the immutable commit tag instead of a mutable `:latest`. Rolling back redeploys the target deployment's commit tag, or rebuilds that commit if its image is no longer in the registry.

## Changes

- **Registry** (`registry.service.ts`): tag-aware URL helpers and a helper that builds a `latest,<short-sha>` name list for BuildKit.
- **Build** (`build.service.ts`, both build-job builders): push `latest` + short-sha for apps; `buildWorkload` accepts an optional target commit (skips head resolution).
- **Deploy** (`deployment.service.ts`): pin the container image to the commit tag; mark rollback deployments via a `qs-is-rollback` annotation.
- **Rollback flow** (`app.service.ts` + `overview/actions.ts`): `rollbackToDeployment` redeploys the cached commit image or starts a new build at that commit.
- **UI** (`deployments.tsx`): Rollback button per deployment row and a Rollback badge.

## Notes

- Rollback only reverts code (git commit); app config (env, ports, domains, replicas) comes from the current DB state.
- Scoped to apps; agent builds are unchanged.

## Testing

- Added `shortGitHash` unit tests and rollback flow unit tests (`app.service.unit.spec.ts`).
- Extended builder unit tests to assert the double-tag output.
- `eslint` clean; targeted unit suites pass.