### PR TITLE
feat: add App build arguments for Dockerfile builds

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -217,6 +217,14 @@ _Avoid_: SSH repo
 A container image reference QuickStack uses to run an **App** or **Agent** without building from Git.
 _Avoid_: Docker Container when referring to the domain concept
 
+**App Environment Variable**:
+A user-defined runtime environment value injected into an **App** container.
+_Avoid_: build argument, build-time variable, secret
+
+**App Build Argument**:
+A user-defined value made available to an **App**'s container image build as a Docker build argument, and never injected at runtime.
+_Avoid_: build environment variable, build-time env var, runtime environment variable
+
 **Deploy Key**:
 A public SSH key registered with a Git provider to grant repository access to a **Git SSH Source**.
 _Avoid_: SSH key when specifically referring to the provider-side access grant
@@ -325,6 +333,11 @@ _Avoid_: manual initial port requirement
 - QuickStack uses a **LiteLLM Admin Key** to list **LiteLLM Model Aliases** and manage Agent virtual keys.
 - A **Project Workload** means an **App** inside an **App Project** or an **Agent** inside an **Agent Project**.
 - A **Workload Permission** belongs to exactly one **Project Workload**.
+- An **App** can have zero or more **App Environment Variables**.
+- An **App** can have zero or more **App Build Arguments**.
+- An **App Build Argument** is available only while building a Dockerfile-based **App**.
+- Runtime **App Environment Variables** are never passed as **App Build Arguments**, and **App Build Arguments** are never injected at runtime.
+- **App Build Argument** values are not secret and must not hold sensitive data.
 - An **App** can have zero or more **App Node Ports**.
 - An **App** has exactly one active **App Network Policy Configuration**.
 - Traffic between replicas of the same **App** is always permitted and cannot be disabled.
@@ -361,6 +374,7 @@ _Avoid_: manual initial port requirement
 - An **App Project Assignment** is set once on create and cannot be changed by update.
 - An **App** write via REST API uses **Full Schema Write** semantics: all required business fields must be present on every create and update, and all sub-collections are fully replaced.
 - An **App** update must include `projectId` and its value must equal the existing **App Project Assignment**.
+- An **App** write via REST API must include **App Build Arguments**; like `envVars`, the field is required on every create and update even when empty.
 - A **User** performs **API Key Self-Management** only for their own **REST API Keys**.
 - **API Key Self-Management** is implemented through profile UI and Next.js Server Actions, not REST API endpoints.
 - A successful **REST API** response uses **Direct Success Payload**.
@@ -398,6 +412,7 @@ _Avoid_: manual initial port requirement
 - "connect to a git https" means configuring a **Git HTTPS Source** for an **App**.
 - "no app source chosen" means the **App** has no **Configured Source**, even if storage contains a default source type.
 - "Docker Container Image" is the UI label for a **Container Image Source**.
+- "build env variable" / "build-time variable" means an **App Build Argument**, never an **App Environment Variable**.
 - "branch" means the selected **Git Branch**, not a build branch or deployment branch.
 - "node portforwarding" means an **App Node Port**, not an ad hoc developer port-forward session.
 - "CRUD REST API" for projects and apps means REST reads/deletes plus **POST Upsert** for create and update.

--- a/docs/adr/0008-build-arguments-plaintext.md
+++ b/docs/adr/0008-build-arguments-plaintext.md
@@ -1,0 +1,3 @@
+# App Build Arguments are plaintext Docker build arguments
+
+An **App** can declare **App Build Arguments** that QuickStack passes to a Dockerfile build as BuildKit `build-arg` options, stored plaintext alongside runtime environment variables. Values therefore appear in image metadata and build-job output and must not hold secrets. We chose this over BuildKit secret mounts because secrets require the user to author `RUN --mount=type=secret` in their Dockerfile, which changes the user contract; plaintext `ARG` matches how Dockerfile authors already expect build arguments to work.

--- a/prisma/migrations/20260911153023_add_app_build_args/migration.sql
+++ b/prisma/migrations/20260911153023_add_app_build_args/migration.sql
@@ -1,0 +1,53 @@
+-- RedefineTables
+PRAGMA defer_foreign_keys=ON;
+PRAGMA foreign_keys=OFF;
+CREATE TABLE "new_App" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "name" TEXT NOT NULL,
+    "appType" TEXT NOT NULL DEFAULT 'APP',
+    "projectId" TEXT NOT NULL,
+    "sourceType" TEXT NOT NULL DEFAULT 'GIT',
+    "buildMethod" TEXT NOT NULL DEFAULT 'RAILPACK',
+    "containerImageSource" TEXT,
+    "containerRegistryUsername" TEXT,
+    "containerRegistryPassword" TEXT,
+    "containerCommand" TEXT,
+    "containerArgs" TEXT,
+    "securityContextRunAsUser" INTEGER,
+    "securityContextRunAsGroup" INTEGER,
+    "securityContextFsGroup" INTEGER,
+    "securityContextPrivileged" BOOLEAN DEFAULT false,
+    "gitUrl" TEXT,
+    "gitBranch" TEXT,
+    "gitUsername" TEXT,
+    "gitToken" TEXT,
+    "dockerfilePath" TEXT NOT NULL DEFAULT './Dockerfile',
+    "replicas" INTEGER NOT NULL DEFAULT 1,
+    "envVars" TEXT NOT NULL DEFAULT '',
+    "buildArgs" TEXT NOT NULL DEFAULT '',
+    "memoryReservation" INTEGER,
+    "memoryLimit" INTEGER,
+    "cpuReservation" INTEGER,
+    "cpuLimit" INTEGER,
+    "webhookId" TEXT,
+    "ingressNetworkPolicy" TEXT NOT NULL DEFAULT 'ALLOW_ALL',
+    "egressNetworkPolicy" TEXT NOT NULL DEFAULT 'ALLOW_ALL',
+    "useNetworkPolicy" BOOLEAN NOT NULL DEFAULT true,
+    "networkPolicyMode" TEXT NOT NULL DEFAULT 'EXTENDED',
+    "healthChechHttpGetPath" TEXT,
+    "healthCheckHttpScheme" TEXT,
+    "healthCheckHttpHeadersJson" TEXT,
+    "healthCheckHttpPort" INTEGER,
+    "healthCheckPeriodSeconds" INTEGER NOT NULL DEFAULT 15,
+    "healthCheckTimeoutSeconds" INTEGER NOT NULL DEFAULT 5,
+    "healthCheckFailureThreshold" INTEGER NOT NULL DEFAULT 3,
+    "healthCheckTcpPort" INTEGER,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL,
+    CONSTRAINT "App_projectId_fkey" FOREIGN KEY ("projectId") REFERENCES "Project" ("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+INSERT INTO "new_App" ("appType", "buildMethod", "containerArgs", "containerCommand", "containerImageSource", "containerRegistryPassword", "containerRegistryUsername", "cpuLimit", "cpuReservation", "createdAt", "dockerfilePath", "egressNetworkPolicy", "envVars", "gitBranch", "gitToken", "gitUrl", "gitUsername", "healthChechHttpGetPath", "healthCheckFailureThreshold", "healthCheckHttpHeadersJson", "healthCheckHttpPort", "healthCheckHttpScheme", "healthCheckPeriodSeconds", "healthCheckTcpPort", "healthCheckTimeoutSeconds", "id", "ingressNetworkPolicy", "memoryLimit", "memoryReservation", "name", "networkPolicyMode", "projectId", "replicas", "securityContextFsGroup", "securityContextPrivileged", "securityContextRunAsGroup", "securityContextRunAsUser", "sourceType", "updatedAt", "useNetworkPolicy", "webhookId") SELECT "appType", "buildMethod", "containerArgs", "containerCommand", "containerImageSource", "containerRegistryPassword", "containerRegistryUsername", "cpuLimit", "cpuReservation", "createdAt", "dockerfilePath", "egressNetworkPolicy", "envVars", "gitBranch", "gitToken", "gitUrl", "gitUsername", "healthChechHttpGetPath", "healthCheckFailureThreshold", "healthCheckHttpHeadersJson", "healthCheckHttpPort", "healthCheckHttpScheme", "healthCheckPeriodSeconds", "healthCheckTcpPort", "healthCheckTimeoutSeconds", "id", "ingressNetworkPolicy", "memoryLimit", "memoryReservation", "name", "networkPolicyMode", "projectId", "replicas", "securityContextFsGroup", "securityContextPrivileged", "securityContextRunAsGroup", "securityContextRunAsUser", "sourceType", "updatedAt", "useNetworkPolicy", "webhookId" FROM "App";
+DROP TABLE "App";
+ALTER TABLE "new_App" RENAME TO "App";
+PRAGMA foreign_keys=ON;
+PRAGMA defer_foreign_keys=OFF;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -421,8 +421,9 @@ model App {
   gitToken       String?
   dockerfilePath String  @default("./Dockerfile")
 
-  replicas Int    @default(1)
-  envVars  String @default("")
+  replicas  Int    @default(1)
+  envVars   String @default("")
+  buildArgs String @default("")
 
   memoryReservation Int?
   memoryLimit       Int?

--- a/src/__tests__/git-test-repositories.utils.ts
+++ b/src/__tests__/git-test-repositories.utils.ts
@@ -28,6 +28,7 @@ export function createGitApp(input: Pick<AppExtendedModel, 'id' | 'sourceType' |
         dockerfilePath: './Dockerfile',
         replicas: 1,
         envVars: '',
+        buildArgs: '',
         useNetworkPolicy: true,
         healthCheckPeriodSeconds: 15,
         healthCheckTimeoutSeconds: 5,

--- a/src/__tests__/integration/server/api/v1/api.integration.spec.ts
+++ b/src/__tests__/integration/server/api/v1/api.integration.spec.ts
@@ -449,6 +449,7 @@ function createGitAppPayload(id: string | undefined, projectId: string, name: st
         dockerfilePath: './Dockerfile',
         replicas: 1,
         envVars: '',
+        buildArgs: '',
         useNetworkPolicy: true,
         healthCheckPeriodSeconds: 15,
         healthCheckTimeoutSeconds: 5,

--- a/src/__tests__/integration/server/api/v1/subitem-identity.integration.spec.ts
+++ b/src/__tests__/integration/server/api/v1/subitem-identity.integration.spec.ts
@@ -165,10 +165,12 @@ describe('REST API v1 integration - nested subitem identity', () => {
             body: {
                 ...savedWithRule,
                 envVars: 'UPDATED=true',
+                buildArgs: 'BUILD_FLAG=1',
             },
         })) as AppExtendedModel;
 
         expect(updated.envVars).toBe('UPDATED=true');
+        expect(updated.buildArgs).toBe('BUILD_FLAG=1');
         expect(updated.appNetworkPolicy).toMatchObject({
             rules: [expect.objectContaining({ id: ruleId, targetAppId: targetApp.id, port: 443 })],
         });
@@ -451,6 +453,7 @@ function createAppPayload(id: string | undefined, projectId: string, name: strin
         dockerfilePath: './Dockerfile',
         replicas: 1,
         envVars: '',
+        buildArgs: '',
         useNetworkPolicy: true,
         healthCheckPeriodSeconds: 15,
         healthCheckTimeoutSeconds: 5,

--- a/src/__tests__/integration/server/services/app.service.integration.spec.ts
+++ b/src/__tests__/integration/server/services/app.service.integration.spec.ts
@@ -225,6 +225,7 @@ function createAppPayload(projectId: string, name: string, hostname: string): Ap
         dockerfilePath: './Dockerfile',
         replicas: 1,
         envVars: '',
+        buildArgs: '',
         useNetworkPolicy: true,
         healthCheckPeriodSeconds: 15,
         healthCheckTimeoutSeconds: 5,

--- a/src/__tests__/integration/server/services/build.service.integration.spec.ts
+++ b/src/__tests__/integration/server/services/build.service.integration.spec.ts
@@ -212,6 +212,7 @@ function createBuildApp(input: BuildIntegrationInput & { id: string; projectId: 
         gitBranch: GitTestRepositories.branch,
         replicas: 1,
         envVars: '',
+        buildArgs: '',
         useNetworkPolicy: true,
         healthCheckPeriodSeconds: 15,
         healthCheckTimeoutSeconds: 5,

--- a/src/__tests__/integration/server/services/network-policy.service.integration.spec.ts
+++ b/src/__tests__/integration/server/services/network-policy.service.integration.spec.ts
@@ -282,6 +282,7 @@ function createNginxApp(): AppExtendedModel {
         dockerfilePath: './Dockerfile',
         replicas: 1,
         envVars: '',
+        buildArgs: '',
         memoryReservation: null,
         memoryLimit: null,
         cpuReservation: null,

--- a/src/app/project/app/[appId]/environment/env-edit.tsx
+++ b/src/app/project/app/[appId]/environment/env-edit.tsx
@@ -3,7 +3,7 @@
 import type { z } from "zod";
 import { SubmitButton } from "@/components/custom/submit-button";
 import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from "@/components/ui/card";
-import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from "@/components/ui/form";
+import { Form, FormControl, FormDescription, FormField, FormItem, FormLabel, FormMessage } from "@/components/ui/form";
 import { FormUtils } from "@/frontend/utils/form.utilts";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useForm } from "react-hook-form";
@@ -29,12 +29,14 @@ export default function EnvEdit({ app, readonly }: {
     const [state, formAction] = useActionState((state: ServerActionResult<any, any>, payload: AppEnvVariablesModel) => saveEnvVariables(state, payload, app.id), FormUtils.getInitialFormState<typeof appEnvVariablesZodModel>());
     useEffect(() => {
         if (state.status === 'success') {
-            toast.success('Env Variables Limits Saved', {
-                description: "Click \"deploy\" to apply the changes to your app.",
+            toast.success('Environment Settings Saved', {
+                description: "Click \"deploy\" to apply the changes to your app. Build arguments apply on the next build.",
             });
         }
         FormUtils.mapValidationErrorsToForm<typeof appEnvVariablesZodModel>(state, form);
     }, [form, state]);
+
+    const buildArgsEnabled = app.appType === 'APP' && app.buildMethod === 'DOCKERFILE';
 
     return <>
         <Card>
@@ -50,7 +52,7 @@ export default function EnvEdit({ app, readonly }: {
                 <form action={() => form.handleSubmit((data) => {
                     return formAction(data);
                 })()}>
-                    <CardContent className="space-y-4">
+                    <CardContent className="space-y-6">
                         <FormField
                             control={form.control}
                             name="envVars"
@@ -60,6 +62,34 @@ export default function EnvEdit({ app, readonly }: {
                                     <FormControl>
                                         <Textarea className="h-96" placeholder="NAME=VALUE..." {...field} value={field.value} />
                                     </FormControl>
+                                    <FormMessage />
+                                </FormItem>
+                            )}
+                        />
+                        <FormField
+                            control={form.control}
+                            name="buildArgs"
+                            render={({ field }) => (
+                                <FormItem>
+                                    <FormLabel>Build Arguments</FormLabel>
+                                    <FormControl>
+                                        <Textarea
+                                            className="h-48"
+                                            placeholder="NAME=VALUE..."
+                                            {...field}
+                                            value={field.value}
+                                            disabled={readonly || !buildArgsEnabled}
+                                        />
+                                    </FormControl>
+                                    <FormDescription>
+                                        Passed to Docker as build arguments (KEY=VALUE) while building the image only.
+                                        They are not available at runtime, are not secret, and apply on the next build.
+                                    </FormDescription>
+                                    {!buildArgsEnabled && (
+                                        <FormDescription>
+                                            Only available for Apps that build with a Dockerfile.
+                                        </FormDescription>
+                                    )}
                                     <FormMessage />
                                 </FormItem>
                             )}

--- a/src/server/services/app.service.unit.spec.ts
+++ b/src/server/services/app.service.unit.spec.ts
@@ -272,6 +272,7 @@ function createApp(overrides: Partial<AppExtendedModel>): AppExtendedModel {
         dockerfilePath: './Dockerfile',
         replicas: 1,
         envVars: '',
+        buildArgs: '',
         memoryReservation: null,
         memoryLimit: null,
         cpuReservation: null,

--- a/src/server/services/build-job-builders/dockerfile-build-job-builder.service.ts
+++ b/src/server/services/build-job-builders/dockerfile-build-job-builder.service.ts
@@ -5,6 +5,7 @@ import buildQueueInitContainer from "./build-init-container.service";
 import buildGitInitContainerService, { BUILD_GIT_SSH_KEY_VOLUME_NAME } from "./build-git-init-container.service";
 import registryService, { BUILD_NAMESPACE } from "../registry.service";
 import { PathUtils } from "@/server/utils/path.utils";
+import { EnvVarUtils } from "@/server/utils/env-var.utils";
 import { BUILD_SOURCE_PATH, BUILD_WORKSPACE_MOUNT_PATH, BUILD_WORKSPACE_VOLUME_NAME } from "./build-workspace.constants";
 import { BuildJobAnnotationsUtils } from "./build-job-annotations.utils";
 
@@ -31,6 +32,11 @@ class DockerfileBuildJobBuilder implements BuildJobBuilder {
             "--output",
             `type=image,"name=${imageNames}",push=true,registry.insecure=true`
         ];
+
+        const buildArgs = 'buildArgs' in ctx.workload ? EnvVarUtils.parseBuildArgs(ctx.workload) : [];
+        for (const buildArg of buildArgs) {
+            buildkitArgs.push("--opt", `build-arg:${buildArg.name}=${buildArg.value}`);
+        }
 
         return {
             apiVersion: "batch/v1",

--- a/src/server/services/build-job-builders/dockerfile-build-job-builder.service.unit.spec.ts
+++ b/src/server/services/build-job-builders/dockerfile-build-job-builder.service.unit.spec.ts
@@ -82,6 +82,32 @@ describe('DockerfileBuildJobBuilder', () => {
         expect(imageOutputArg).not.toContain(':latest');
     });
 
+    it('passes build arguments to BuildKit as build-arg options', async () => {
+        const job = await dockerfileBuildJobBuilder.buildJobDefinition({
+            workload: {
+                id: 'app-1',
+                projectId: 'project-1',
+                gitUrl: 'https://github.com/example/repo.git',
+                gitBranch: 'main',
+                dockerfilePath: './Dockerfile',
+                buildArgs: 'FOO=bar\nBAZ=qux=quux',
+            } as any,
+            workloadType: 'app',
+            buildName: 'build-1',
+            deploymentId: 'deployment-1',
+            latestRemoteGitHash: 'abc123',
+            latestRemoteGitCommitMessage: 'feat: test',
+            queuedAt: '123',
+            maxParallelBuilds: 2,
+        });
+
+        expect(job.spec?.template?.spec?.containers[0]?.args).toEqual(expect.arrayContaining([
+            '--opt',
+            'build-arg:FOO=bar',
+            'build-arg:BAZ=qux=quux',
+        ]));
+    });
+
     it('adds an SSH key secret volume when provided', async () => {
         const job = await dockerfileBuildJobBuilder.buildJobDefinition({
             workload: {

--- a/src/server/services/svc.service.unit.spec.ts
+++ b/src/server/services/svc.service.unit.spec.ts
@@ -170,6 +170,7 @@ function createApp(overrides: Partial<AppExtendedModel>): AppExtendedModel {
         dockerfilePath: './Dockerfile',
         replicas: 1,
         envVars: '',
+        buildArgs: '',
         memoryReservation: null,
         memoryLimit: null,
         cpuReservation: null,

--- a/src/server/utils/env-var.utils.ts
+++ b/src/server/utils/env-var.utils.ts
@@ -8,4 +8,14 @@ export class EnvVarUtils {
             return { name, value };
         }) : [];
     }
+
+    static parseBuildArgs(app: AppExtendedModel) {
+        return app.buildArgs ? app.buildArgs.split('\n').filter(x => !!x).map(buildArg => {
+            const separatorIndex = buildArg.indexOf('=');
+            if (separatorIndex === -1) {
+                return { name: buildArg, value: '' };
+            }
+            return { name: buildArg.slice(0, separatorIndex), value: buildArg.slice(separatorIndex + 1) };
+        }) : [];
+    }
 }

--- a/src/server/utils/env-var.utils.unit.spec.ts
+++ b/src/server/utils/env-var.utils.unit.spec.ts
@@ -1,0 +1,72 @@
+import { EnvVarUtils } from "./env-var.utils";
+import { AppExtendedModel } from "@/shared/model/app-extended.model";
+
+function appWithEnvVars(envVars: string, buildArgs: string): AppExtendedModel {
+    return { envVars, buildArgs } as AppExtendedModel;
+}
+
+describe('EnvVarUtils', () => {
+    describe('parseEnvVariables', () => {
+        it('parses newline separated KEY=VALUE pairs', () => {
+            const app = appWithEnvVars('FOO=bar\nBAZ=qux', '');
+
+            expect(EnvVarUtils.parseEnvVariables(app)).toEqual([
+                { name: 'FOO', value: 'bar' },
+                { name: 'BAZ', value: 'qux' },
+            ]);
+        });
+
+        it('ignores empty lines', () => {
+            const app = appWithEnvVars('FOO=bar\n\nBAZ=qux\n', '');
+
+            expect(EnvVarUtils.parseEnvVariables(app)).toEqual([
+                { name: 'FOO', value: 'bar' },
+                { name: 'BAZ', value: 'qux' },
+            ]);
+        });
+
+        it('returns an empty list when no env variables are set', () => {
+            expect(EnvVarUtils.parseEnvVariables(appWithEnvVars('', ''))).toEqual([]);
+        });
+    });
+
+    describe('parseBuildArgs', () => {
+        it('parses newline separated KEY=VALUE build arguments', () => {
+            const app = appWithEnvVars('', 'FOO=bar\nBAZ=qux');
+
+            expect(EnvVarUtils.parseBuildArgs(app)).toEqual([
+                { name: 'FOO', value: 'bar' },
+                { name: 'BAZ', value: 'qux' },
+            ]);
+        });
+
+        it('splits on the first equals sign so values may contain equals signs', () => {
+            const app = appWithEnvVars('', 'TOKEN=a=b=c');
+
+            expect(EnvVarUtils.parseBuildArgs(app)).toEqual([
+                { name: 'TOKEN', value: 'a=b=c' },
+            ]);
+        });
+
+        it('treats a line without an equals sign as an empty value', () => {
+            const app = appWithEnvVars('', 'STANDALONE');
+
+            expect(EnvVarUtils.parseBuildArgs(app)).toEqual([
+                { name: 'STANDALONE', value: '' },
+            ]);
+        });
+
+        it('ignores empty lines', () => {
+            const app = appWithEnvVars('', 'FOO=bar\n\nBAZ=qux\n');
+
+            expect(EnvVarUtils.parseBuildArgs(app)).toEqual([
+                { name: 'FOO', value: 'bar' },
+                { name: 'BAZ', value: 'qux' },
+            ]);
+        });
+
+        it('returns an empty list when no build arguments are set', () => {
+            expect(EnvVarUtils.parseBuildArgs(appWithEnvVars('', ''))).toEqual([]);
+        });
+    });
+});

--- a/src/shared/model/app-template.model.ts
+++ b/src/shared/model/app-template.model.ts
@@ -11,6 +11,7 @@ const appModelWithRelations = z.lazy(() => AppModel.omit({
     projectId: z.undefined().optional(),
     buildMethod: z.undefined().optional(),
     dockerfilePath: z.undefined().optional(),
+    buildArgs: z.string().optional(),
     appType: appTypeZodModel,
     sourceType: appSourceTypeZodModel,
     id: z.undefined().optional(),

--- a/src/shared/model/env-edit.model.ts
+++ b/src/shared/model/env-edit.model.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 
 export const appEnvVariablesZodModel = z.object({
   envVars: z.string(),
+  buildArgs: z.string(),
 })
 
 export type AppEnvVariablesModel = z.infer<typeof appEnvVariablesZodModel>;

--- a/src/shared/model/generated-zod/app.ts
+++ b/src/shared/model/generated-zod/app.ts
@@ -25,6 +25,7 @@ export const AppModel = z.object({
   dockerfilePath: z.string(),
   replicas: z.number().int(),
   envVars: z.string(),
+  buildArgs: z.string(),
   memoryReservation: z.number().int().nullish(),
   memoryLimit: z.number().int().nullish(),
   cpuReservation: z.number().int().nullish(),


### PR DESCRIPTION
## Summary

Apps that build from a Dockerfile can now declare **build-time variables** (Docker build arguments) next to runtime env vars in the Environment tab. They are stored in a new `App.buildArgs` column and passed to BuildKit as `--opt build-arg:KEY=VALUE`.

## Domain decisions

- New **App Build Argument** term; strictly separate from **App Environment Variable**. Never injected at runtime, never sourced from runtime env vars.
- Build arguments are **plaintext** and leak into image metadata/history. UI warns: not for secrets. See `docs/adr/0008-build-arguments-plaintext.md`.
- Scope: Apps with `buildMethod === 'DOCKERFILE'` only. The field is shown but disabled for Railpack/container/database Apps; values persist and are ignored.
- REST App full-schema writes now require `buildArgs` (strict Full Schema Write); documented in `CONTEXT.md`.

## Changes

- Prisma: `App.buildArgs String @default("")` + migration.
- `EnvVarUtils.parseBuildArgs` (splits on first `=`, ignores empty lines).
- Dockerfile build job builder appends BuildKit build-arg options.
- Environment tab second textarea with hints ("applies on next build", not secret).
- Tests: `env-var.utils.unit.spec.ts`, builder build-arg test, REST round-trip assertion; fixtures updated.

## Verification

- `yarn lint` clean.
- `npx tsc --noEmit` clean for changed code (remaining errors are pre-existing `elkjs` typing issues).
- Unit tests: `env-var.utils`, dockerfile builder, `app.service`, `svc.service`, `app-template.utils` all pass.

## Notes

- No auto-rebuild: new build arguments take effect on the next build.